### PR TITLE
Minor documentation edits

### DIFF
--- a/documentation/architecture_and_design.rst
+++ b/documentation/architecture_and_design.rst
@@ -5,16 +5,16 @@ Architecture and Design
 Background from Reinforcement Learning
 ======================================
 
-In Reinforcement Learning (RL), the basic control loop is between agent and environment, as shown in :numref:`fig_trad_rl_arch`. An environment (or env) is a stateful object analogous to a simplified version of the world we live in. In a programming language, an Env (e.g., OpenAI’s gym.Env) is often an object with a function called step that takes an action and returns an observation (or “state”) and reward. 
+In Reinforcement Learning (RL), the basic control loop is between agent and environment, as shown in :numref:`fig_trad_rl_arch`. An environment (or env) is a stateful object analogous to a simplified version of the world we live in. In a programming language, an Env (e.g., OpenAI’s gym.Env) is often an object with a ``step()`` function that takes an action and returns an observation (or “state”) and reward.
 
-An agent essentially encapsulates the ability to make a decision and act in that env. An agent usually contains a policy which is a function that takes an (observation, reward) pair and returns an action.
+An agent encapsulates the ability to make a decision and act in that env. An agent usually contains a policy which is a function that takes an (observation, reward) pair and returns an action.
 
 .. _fig_trad_rl_arch:
 .. figure:: traditional_rl_agent_arch.png
   :width: 80%
   :align: center
 
-  The traditional RL view of the loop between Agent (green) and Environment (blue). The information that passes between them at a given time step t includes: action A\ :subscript:`t`, state (a.k.a, observation) St, and reward Rt.  Image modified from `Sutton & Barto <http://incompleteideas.net/book/the-book-2nd.html>`_ figure 3.1 (pg 48).
+  The traditional RL view of the loop between Agent (green) and Environment (blue). The information that passes between them at a given time step t includes: action A\ :subscript:`t`, state (a.k.a, observation) S\ :subscript:`t`, and reward R\ :subscript:`t`.  Image modified from `Sutton & Barto <http://incompleteideas.net/book/the-book-2nd.html>`_ figure 3.1 (pg 48).
 
 .. _fig_agentos_agent_arch:
 .. figure:: agentos_agent_arch.png
@@ -38,17 +38,17 @@ The following are high-level descriptions of key AgentOS concepts.
 
 **AgentOS**. A project that contains tools, APIs, and conventions for building, managing, and sharing learning agents.
 
-**Environment**. Environments have ``step()`` and ``reset()`` functions as they are defined in gym.Env. We recommend making a class that inherits from ``gym.Env``.
+**Environment**. Environments have ``step()`` and ``reset()`` functions as they are defined in ``gym.Env``. We recommend making a class that inherits from ``gym.Env``.
 
 **Policy**. Policies have a ``compute_action()`` function which the agent can use to decide on their next action, given the most recent observation returned from the agent’s environment.
 
-**Agent**. A python class that has a advance() function that returns a boolean, and encapsulates the agent behavior necessary to take steps in its environment:
+**Agent**. A Python class that has an ``advance()`` function that returns a boolean, and encapsulates the agent behavior necessary to take steps in its environment:
 
   * choose actions (e.g. a policy)
   * takes actions by calling ``self.env.step()``
   * learn from -- or otherwise updates internal state based on -- return value of ``self.env.step()``
 
-AgentOS provides agentos.Agent as a reference implementation of an abstract agent base class. A running agent is called an agent instance.
+AgentOS provides ``agentos.Agent`` as a reference implementation of an abstract agent base class. A running agent is called an agent instance.
 
 **Agent Runner**.
 Code that runs an agent by calling ``agent.advance()`` till it returns done. It might also instantiate the agent (or it might take an agent instance).
@@ -73,9 +73,9 @@ Architecture
 
 Mode of Interacting with AgentOS
 =================================
-Agents, policies, environments, etc. are written in python. Agent instances can be run via python in scripts or interactively with ``agentos.run_agent()`` or via the CLI.
+Agents, policies, environments, etc. are written in Python. Agent instances can be run via Python in scripts or interactively with ``agentos.run_agent()`` or via the CLI.
 
-The CLI supports a few basic commands: 
+The CLI supports a few basic commands:
   * ``agentos init`` - create files that define an example agent in the current directory.
   * ``agentos run`` - run an agent. Supports a few convenient ways to specify the agent class and env class that make up the agent instance. If called without any args, tries to run the current dir as an MLflow project, else looks for agent and env class definitions in agent.py. Under the hood, regardless of which argument option is used, ``agentos.run_agent()`` is called. See the pydocs for full details.
 

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -2,11 +2,11 @@
 
 AgentOS: a learning agent platform
 ==================================
-AgentOS is a **command line interface and python developer API** for building, running, and sharing flexible learning agents.
+AgentOS is a **command line interface and Python developer API** for building, running, and sharing flexible learning agents.
 
 Key features include:
   * Easy to use Agent API for developing and running new agents.
-  * Re-use OpenAI's Gym Environment abstraction.
+  * Reuse OpenAI's Gym Environment abstraction.
 
 .. toctree::
    :hidden:

--- a/documentation/motivation.rst
+++ b/documentation/motivation.rst
@@ -12,7 +12,7 @@ Motivation
 Many researchers and developers across reinforcement learning, robotics, AI, NLP, neuroscience, machine learning, cognitive science, psychology, business build learning agents (for example, `Ray RLlib`_, Nengo_, Soar_, `ACT-R <http://act-r.psy.cmu.edu>`_, `ROS <https://www.ros.org/>`_, MyCroft_, `Google Assistant <https://assistant.google.com>`_, `Apple's Siri <https://www.apple.com/siri/>`_).
 
 .. figure:: agent_landscape.png
-  :width: 70% 
+  :width: 70%
   :align: center
 
   The learning agent landscape. Each box represents a different discipline or area where learning agents are used.
@@ -27,13 +27,13 @@ While there exist open source APIs and implementations for Environments (e.g., O
 
 Thus, each researcher or developer designs and implements their own agent architecture, including how the agent interacts with an environment, organizes trials (or “rollouts”) used for learning, stores memories in some format, uses experience for learning, etc. (e.g., `Berkeley CS285 RL Course`_, Soar_, ROS_, Mycroft_).
 
-To rapidly build new agents, it should be easy to focus on one new sub-system and not have to re-create all of the other necessary functionality from scratch. 
+To rapidly build new agents, it should be easy to focus on one new sub-system and not have to re-create all of the other necessary functionality from scratch.
 
 It should also be easy to upgrade an agent so that it starts using a learning algorithm released/maintained by somebody else, similar to how we can upgrade an application or an operating system component like a file system.
 
 However, most existing systems that support agent development are monolithic and do not provide standard interoperable components. For example, OpenAI Baselines algorithms cannot easily be plugged into a Ray Trainer or an instance of MyCroft; neither can a memory module from ACT-R be easily plugged into Soar, EPIC, OpenCog, or any other cognitive architecture or agent architecture.
 
-In contrast, the popular RL ``gym.Env`` API built by OpenAI is simple, accessible, and RL classes (e.g., `Berkeley CS285 RL Course`_) and RL frameworks (`Ray RLlib`_, `Tensorflow Agents`_, `TensorForce`_) are using it as a standard. 
+In contrast, the popular RL ``gym.Env`` API built by OpenAI is simple, accessible, and RL classes (e.g., `Berkeley CS285 RL Course`_) and RL frameworks (`Ray RLlib`_, `Tensorflow Agents`_, `TensorForce`_) are using it as a standard.
 
 We would like to see a similar standardization happen for the structure of a learning Agent itself, and related common components (e.g., behavior policy, memory). We hope that the AgentOS ``Agent`` and related abstractions -- with their simplistic and modular design -- might inspire new open source de facto standards that accelerate building and researching learning agents.
 

--- a/documentation/quickstart.rst
+++ b/documentation/quickstart.rst
@@ -1,14 +1,14 @@
 ***********
 Quick Start
 ***********
-AgentOS is a **command line interface and python developer API** for building, running, and sharing flexible learning agents.
+AgentOS is a **command line interface and Python developer API** for building, running, and sharing flexible learning agents.
 
 AgentOS proposes a standard minimal architecture for a learning agent, and includes an API and example agent implementations for developers. The benefits of standard agent-related abstractions include:
 
   * It is easier and faster to build agents since creators can focus on what is important to them without having to rewrite the parts that are less interesting but necessary in all agents (e.g., code to manage long running processes, parallelism, etc.).
   * A simple open standard makes it easier to talk about agents, share agent code, and quickly understand agents created by others. These benefits are similar to those of the OpenAI Gym standard API for agent environments (`gym.Env <https://github.com/openai/gym/blob/master/gym/core.py>`_).
 
-The best way to understand AgentOS is to use it, so let’s install agentos and write a simple agent in python that behaves randomly. Installation is easy::
+The best way to understand AgentOS is to use it, so let’s install agentos and write a simple agent in Python that behaves randomly. Installation is easy::
 
   $ pip install agentos
   $ pip install gym  # AgentOS uses OpenAI Gym's Environment abstraction.
@@ -26,7 +26,7 @@ Writing a trivial agent is also easy::
 
 That’s it. Only one function is required to create an agent: ``advance()``. It takes no arguments, has access to the agent’s environment, and returns a boolean indicating if the agent is done.
 
-Next let’s open a python shell::
+Next let’s open a Python shell::
 
   $ python
 
@@ -39,7 +39,7 @@ Next let’s open a python shell::
   Took a random step, done = False.
   False
 
-The return value of False indicates that the agent is not yet “done”. Notice that in this code we are using an OpenAI gym environment (more about that below).
+The return value of ``False`` indicates that the agent is not yet “done”. Notice that in this code we are using an OpenAI gym environment (more about that below).
 
 Let’s continue running our agent using a while loop until it is done::
 
@@ -53,7 +53,7 @@ Let’s continue running our agent using a while loop until it is done::
 
 The number of steps that the agent takes before being done is random since its behavior is random (also the environment has randomness in it).
 
-Now, instead of writing our own while loop, let’s run the agent in a python Thread using a convenience function that AgentOS provides which serves as an Agent Runner::
+Now, instead of writing our own while loop, let’s run the agent in a Python Thread using a convenience function that AgentOS provides which serves as an Agent Runner::
 
   >>> agentos.run_agent(SimpleAgent, CartPoleEnv)
   Took a random step, done = False.
@@ -69,7 +69,7 @@ Or we can run the agent via the AgentOS CLI::
   Took a random step, done = False.
   Took a random step, done = True.
 
-As an alternative to using our custom agent above, let’s go back into the python shell we opened above and use AgentOS’s RandomAgent::
+As an alternative to using our custom agent above, let’s go back into the Python shell we opened above and use AgentOS’s RandomAgent::
 
   >>> from agentos.agents import RandomAgent
   >>> from gym.envs.classic_control import CartPoleEnv

--- a/documentation/quickstart.rst
+++ b/documentation/quickstart.rst
@@ -45,7 +45,7 @@ Let’s continue running our agent using a while loop until it is done::
 
   >>> done = False
   >>> while not done:
-  >>>     done = agent.step()
+  >>>     done = agent.advance()
   Took a random step, done = False.
   …
   Took a random step, done = False.


### PR DESCRIPTION
A few small edits:
* `agent.step()` -> `agent.advance()`
* Capitalize Python (believe this is standard)
* Remove trailing whitespace
* "Codify" a few things that seemed reasonable to codify (e.g. `False` when referring to the Python boolean)
* A few minor rewrites for clarity

How would you feel if I reflowed the paragraphs to be 80 chars max per line?  Makes editing and diffs easier to read IMO.