### PR TITLE
Reflowed doc RSTs to have 80 chars per line

### DIFF
--- a/documentation/architecture_and_design.rst
+++ b/documentation/architecture_and_design.rst
@@ -5,57 +5,99 @@ Architecture and Design
 Background from Reinforcement Learning
 ======================================
 
-In Reinforcement Learning (RL), the basic control loop is between agent and environment, as shown in :numref:`fig_trad_rl_arch`. An environment (or env) is a stateful object analogous to a simplified version of the world we live in. In a programming language, an Env (e.g., OpenAI’s gym.Env) is often an object with a ``step()`` function that takes an action and returns an observation (or “state”) and reward.
+In Reinforcement Learning (RL), the basic control loop is between agent and
+environment, as shown in :numref:`fig_trad_rl_arch`. An environment (or env) is
+a stateful object analogous to a simplified version of the world we live in. In
+a programming language, an Env (e.g., OpenAI’s gym.Env) is often an object with
+a ``step()`` function that takes an action and returns an observation (or
+“state”) and reward.
 
-An agent encapsulates the ability to make a decision and act in that env. An agent usually contains a policy which is a function that takes an (observation, reward) pair and returns an action.
+An agent encapsulates the ability to make a decision and act in that env. An
+agent usually contains a policy which is a function that takes an (observation,
+reward) pair and returns an action.
 
 .. _fig_trad_rl_arch:
 .. figure:: traditional_rl_agent_arch.png
   :width: 80%
   :align: center
 
-  The traditional RL view of the loop between Agent (green) and Environment (blue). The information that passes between them at a given time step t includes: action A\ :subscript:`t`, state (a.k.a, observation) S\ :subscript:`t`, and reward R\ :subscript:`t`.  Image modified from `Sutton & Barto <http://incompleteideas.net/book/the-book-2nd.html>`_ figure 3.1 (pg 48).
+  The traditional RL view of the loop between Agent (green) and Environment
+  (blue). The information that passes between them at a given time step t
+  includes: action A\ :subscript:`t`, state (a.k.a, observation)
+  S\ :subscript:`t`, and reward R\ :subscript:`t`.  Image modified from `Sutton &
+  Barto <http://incompleteideas.net/book/the-book-2nd.html>`_ figure 3.1 (pg
+  48).
 
 .. _fig_agentos_agent_arch:
 .. figure:: agentos_agent_arch.png
   :width: 80%
   :align: center
 
-  The concepts are very similar in AgentOS, though AgentOS also differentiates between an agent and a policy, and formalizes the relationship between agent, policy, and environment: an agent has a policy and an environment connected in a message passing loop. Calling ``agent.advance()`` causes a single iteration of that loop to occur.
+  The concepts are very similar in AgentOS, though AgentOS also differentiates
+  between an agent and a policy, and formalizes the relationship between agent,
+  policy, and environment: an agent has a policy and an environment connected
+  in a message passing loop. Calling ``agent.advance()`` causes a single
+  iteration of that loop to occur.
 
 
 AgentOS Concepts
 ===================
 
-The RL concepts of an **agent** and its **environment**, as described above are very similar to those in AgentOS. However, AgentOS differs from the classic RL architecture in a few key ways. First, an agent is paired with -- and holds a reference to -- its environment. Second, the agent also can hold a policy. Finally, the agent has an ``advance()`` function, inside of which it takes one step around the core RL loop between the agent’s policy and its environment.
+The RL concepts of an **agent** and its **environment**, as described above are
+very similar to those in AgentOS. However, AgentOS differs from the classic RL
+architecture in a few key ways. First, an agent is paired with -- and holds a
+reference to -- its environment. Second, the agent also can hold a policy.
+Finally, the agent has an ``advance()`` function, inside of which it takes one
+step around the core RL loop between the agent’s policy and its environment.
 
 In terms of design philosophy, environments, policies, and agents are:
 
-  * *Stateful* - an environment tracks internal state (e.g. location of objects in a room), a policy often maintains a machine learning model which can be updated to reflect past learnings; an agent maintains a policy, an environment, as well as arbitrary other state (e.g. recent observations from its env, memory modules, etc.);
-  * *Flexible and minimal* - minimal APIs result in minimal constraints on developers. For example, developers can choose their own concurrency model, architecture, algorithms, etc.
+  * *Stateful* - an environment tracks internal state (e.g. location of objects
+    in a room), a policy often maintains a machine learning model which can be
+    updated to reflect past learnings; an agent maintains a policy, an
+    environment, as well as arbitrary other state (e.g. recent observations
+    from its env, memory modules, etc.);
+
+  * *Flexible and minimal* - minimal APIs result in minimal constraints on
+    developers. For example, developers can choose their own concurrency model,
+    architecture, algorithms, etc.
 
 The following are high-level descriptions of key AgentOS concepts.
 
-**AgentOS**. A project that contains tools, APIs, and conventions for building, managing, and sharing learning agents.
+**AgentOS**. A project that contains tools, APIs, and conventions for building,
+managing, and sharing learning agents.
 
-**Environment**. Environments have ``step()`` and ``reset()`` functions as they are defined in ``gym.Env``. We recommend making a class that inherits from ``gym.Env``.
+**Environment**. Environments have ``step()`` and ``reset()`` functions as they
+are defined in ``gym.Env``. We recommend making a class that inherits from
+``gym.Env``.
 
-**Policy**. Policies have a ``compute_action()`` function which the agent can use to decide on their next action, given the most recent observation returned from the agent’s environment.
+**Policy**. Policies have a ``compute_action()`` function which the agent can
+use to decide on their next action, given the most recent observation returned
+from the agent’s environment.
 
-**Agent**. A Python class that has an ``advance()`` function that returns a boolean, and encapsulates the agent behavior necessary to take steps in its environment:
+**Agent**. A Python class that has an ``advance()`` function that returns a
+boolean, and encapsulates the agent behavior necessary to take steps in its
+environment:
 
   * choose actions (e.g. a policy)
+
   * takes actions by calling ``self.env.step()``
-  * learn from -- or otherwise updates internal state based on -- return value of ``self.env.step()``
 
-AgentOS provides ``agentos.Agent`` as a reference implementation of an abstract agent base class. A running agent is called an agent instance.
+  * learn from -- or otherwise updates internal state based on -- return value
+    of ``self.env.step()``
 
-**Agent Runner**.
-Code that runs an agent by calling ``agent.advance()`` till it returns ``True``. It might also instantiate the agent (or it might take an agent instance).
+AgentOS provides ``agentos.Agent`` as a reference implementation of an abstract
+agent base class. A running agent is called an agent instance.
 
-**CLI**. The Command Line Interface provides some basic commands for creating and running an AgentOS agent, mostly for learning AgentOS.
+**Agent Runner**.  Code that runs an agent by calling ``agent.advance()`` till
+it returns ``True``. It might also instantiate the agent (or it might take an
+agent instance).
 
-**Agent directory**. A directory with standard files needed by AgentOS CLI to create or run an agent using MLflow. Also known as agent project.
+**CLI**. The Command Line Interface provides some basic commands for creating
+and running an AgentOS agent, mostly for learning AgentOS.
+
+**Agent directory**. A directory with standard files needed by AgentOS CLI to
+create or run an agent using MLflow. Also known as agent project.
 
 
 Architecture
@@ -73,9 +115,21 @@ Architecture
 
 Mode of Interacting with AgentOS
 =================================
-Agents, policies, environments, etc. are written in Python. Agent instances can be run via Python in scripts or interactively with ``agentos.run_agent()`` or via the CLI.
+
+Agents, policies, environments, etc. are written in Python. Agent instances can
+be run via Python in scripts or interactively with ``agentos.run_agent()`` or
+via the CLI.
 
 The CLI supports a few basic commands:
-  * ``agentos init`` - create files that define an example agent in the current directory.
-  * ``agentos run`` - run an agent. Supports a few convenient ways to specify the agent class and env class that make up the agent instance. If called without any args, tries to run the current dir as an MLflow project, else looks for agent and env class definitions in agent.py. Under the hood, regardless of which argument option is used, ``agentos.run_agent()`` is called. See the pydocs for full details.
+  * ``agentos init`` - create files that define an example agent in the current
+    directory.
+
+  * ``agentos run`` - run an agent. Supports a few convenient ways to specify
+    the agent class and env class that make up the agent instance. If called
+    without any args, tries to run the current dir as an MLflow project, else
+    looks for agent and env class definitions in agent.py. Under the hood,
+    regardless of which argument option is used, ``agentos.run_agent()`` is
+    called. See the pydocs for full details.
+
+
 

--- a/documentation/example_agents.rst
+++ b/documentation/example_agents.rst
@@ -1,4 +1,6 @@
 Example Agents
 ==============
 
-The ``example_agents`` directory of the `AgentOS source repository <https://github.com/agentos-project/agentos>`_ contains different examples of learning agents.
+The ``example_agents`` directory of the `AgentOS source repository
+<https://github.com/agentos-project/agentos>`_ contains different examples of
+learning agents.

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -2,11 +2,19 @@
 
 AgentOS: a learning agent platform
 ==================================
-AgentOS is an open source **python API and a command line interface** for building, running, and sharing learning agents. AgentOS is licensed under the Apache License, Version 2.0.
+
+AgentOS is an open source **python API and a command line interface** for
+building, running, and sharing learning agents. AgentOS is licensed under the
+Apache License, Version 2.0.
 
 Key features include:
   * Easy to use Agent API for developing and running new agents.
-  * Example learning agents from different disciplines and research areas are available in the `example_agents <https://github.com/agentos-project/agentos/tree/master/example_agents>`_ directory of the project source code.
+
+  * Example learning agents from different disciplines and research areas are
+    available in the
+    `example_agents <https://github.com/agentos-project/agentos/tree/master/example_agents>`_
+    directory of the project source code.
+
   * Reuse of OpenAI's Gym Environment abstraction.
 
 Find the `AgentOS sourcecode on Github <https://github.com/agentos-project/agentos>`_.

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -3,7 +3,7 @@
 AgentOS: a learning agent platform
 ==================================
 
-AgentOS is an open source **python API and a command line interface** for
+AgentOS is an open source **Python API and a command line interface** for
 building, running, and sharing learning agents. AgentOS is licensed under the
 Apache License, Version 2.0.
 

--- a/documentation/motivation.rst
+++ b/documentation/motivation.rst
@@ -13,35 +13,79 @@ Motivation
 .. _Tensorflow Agents: https://www.tensorflow.org/agents
 .. _TensorForce: https://github.com/tensorforce/tensorforce
 
-Many researchers and developers across reinforcement learning, robotics, artificial intelligence, natural language programming (NLP), neuroscience, machine learning, cognitive science, psychology, and business build learning agents (for example, `Ray RLlib`_, Nengo_, Soar_, ACT-R_, `ROS <https://www.ros.org/>`_, MyCroft_, `Google Assistant <https://assistant.google.com>`_, `Apple's Siri <https://www.apple.com/siri/>`_).
+Many researchers and developers across reinforcement learning, robotics,
+artificial intelligence, natural language programming (NLP), neuroscience,
+machine learning, cognitive science, psychology, and business build learning
+agents (for example, `Ray RLlib`_, Nengo_, Soar_, ACT-R_,
+`ROS <https://www.ros.org/>`_, MyCroft_,
+`Google Assistant <https://assistant.google.com>`_,
+`Apple's Siri <https://www.apple.com/siri/>`_).
 
 .. figure:: agent_landscape.png
   :width: 70%
   :align: center
 
-  The learning agent landscape. Each box represents a different discipline or area where learning agents are used.
+  The learning agent landscape. Each box represents a different discipline or
+  area where learning agents are used.
 
 Typically, agents...
 
   * interact with the world via observe -> decide -> act loops
+
   * have goals or intentions, e.g., to maximize a reward signal
-  * are driven by complex inner state, which may include a model of their environment, the value of past actions, or memories of past interactions with the environment
 
-While there exist open source APIs and implementations for Environments (e.g., OpenAI `gym.Env <https://github.com/openai/gym/blob/master/gym/core.py>`_) and learning algorithms (e.g. `Ray RLlib`_, `TensorFlow Agents`_), there has not emerged a de facto standard set of APIs and tools for composing, running, and managing long running learning agents.
+  * are driven by complex inner state, which may include a model of their
+    environment, the value of past actions, or memories of past interactions
+    with the environment
 
-Thus, each researcher or developer designs and implements their own agent architecture, including how the agent interacts with an environment, organizes trials (or “rollouts”) used for learning, stores memories in some format, uses experience for learning, etc. (e.g., `Berkeley CS285 RL Course`_, Soar_, ROS_, Mycroft_).
+While there exist open source APIs and implementations for Environments (e.g.,
+OpenAI `gym.Env <https://github.com/openai/gym/blob/master/gym/core.py>`_) and
+learning algorithms (e.g. `Ray RLlib`_, `TensorFlow Agents`_), there has not
+emerged a de facto standard set of APIs and tools for composing, running, and
+managing long running learning agents.
 
-To rapidly build new agents, it should be easy to focus on one new sub-system and not have to re-create all of the other necessary functionality from scratch.
+Thus, each researcher or developer designs and implements their own agent
+architecture, including how the agent interacts with an environment, organizes
+trials (or “rollouts”) used for learning, stores memories in some format, uses
+experience for learning, etc. (e.g., `Berkeley CS285 RL Course`_, Soar_, ROS_,
+Mycroft_).
 
-It should also be easy to upgrade an agent so that it starts using a learning algorithm released/maintained by somebody else, similar to how we can upgrade an application or an operating system component like a file system.
+To rapidly build new agents, it should be easy to focus on one new sub-system
+and not have to re-create all of the other necessary functionality from
+scratch.
 
-However, most existing systems that support agent development are monolithic and do not provide standard interoperable components. For example, `OpenAI Baselines`_ algorithms cannot easily be plugged into a Ray Trainer or an instance of MyCroft; neither is it easy to plug a memory module from ACT-R_ into Soar_, OpenCog_, or any other cognitive architecture or agent architecture.
+It should also be easy to upgrade an agent so that it starts using a learning
+algorithm released/maintained by somebody else, similar to how we can upgrade
+an application or an operating system component like a file system.
 
-In contrast, the popular RL ``gym.Env`` API built by OpenAI is simple, accessible, and RL classes (e.g., `Berkeley CS285 RL Course`_) and RL frameworks (`Ray RLlib`_, `Tensorflow Agents`_, `TensorForce`_) are using it as a standard.
+However, most existing systems that support agent development are monolithic
+and do not provide standard interoperable components. For example,
+`OpenAI Baselines`_ algorithms cannot easily be plugged into a Ray Trainer or an
+instance of MyCroft; neither is it easy to plug a memory module from ACT-R_
+into Soar_, OpenCog_, or any other cognitive architecture or agent
+architecture.
 
-We would like to see a similar standardization happen for the structure of a learning Agent itself, and related common components (e.g., behavior policy, memory). We hope that the AgentOS ``Agent`` and related abstractions -- with their simplistic and modular design -- might inspire new open source de facto standards that accelerate building and researching learning agents.
+In contrast, the popular RL ``gym.Env`` API built by OpenAI is simple,
+accessible, and RL classes (e.g., `Berkeley CS285 RL Course`_) and RL
+frameworks (`Ray RLlib`_, `Tensorflow Agents`_, `TensorForce`_) are using it as
+a standard.
 
-Finally, we hope that progress towards more general agent behavior might be accelerated by focusing on agents composed of a combination of RL algorithms and learning techniques (perhaps many sub-agents arranged hierarchically) interacting concurrently with many environments (virtual sensors and actuators, and their underlying directly unavailable state), just as humans do. We aim to facilitate and demonstrate this in agents we build using AgentOS.
+We would like to see a similar standardization happen for the structure of a
+learning Agent itself, and related common components (e.g., behavior policy,
+memory). We hope that the AgentOS ``Agent`` and related abstractions -- with
+their simplistic and modular design -- might inspire new open source de facto
+standards that accelerate building and researching learning agents.
 
-In summary, AgentOS aims to make it easy to build and work with agents and their environments. This includes composing agents from common components, and building such components using simple minimalistic APIs. AgentOS does this in a modern way, building on---and interoperating with---existing popular languages, libraries, tools, and frameworks including Python, pip/PyPI, Conda, Git, and MLflow.
+Finally, we hope that progress towards more general agent behavior might be
+accelerated by focusing on agents composed of a combination of RL algorithms
+and learning techniques (perhaps many sub-agents arranged hierarchically)
+interacting concurrently with many environments (virtual sensors and actuators,
+and their underlying directly unavailable state), just as humans do. We aim to
+facilitate and demonstrate this in agents we build using AgentOS.
 
+In summary, AgentOS aims to make it easy to build and work with agents and
+their environments. This includes composing agents from common components, and
+building such components using simple minimalistic APIs. AgentOS does this in a
+modern way, building on---and interoperating with---existing popular languages,
+libraries, tools, and frameworks including Python, pip/PyPI, Conda, Git, and
+MLflow.

--- a/documentation/quickstart.rst
+++ b/documentation/quickstart.rst
@@ -1,14 +1,26 @@
 ***********
 Quick Start
 ***********
-AgentOS is a **command line interface and Python developer API** for building, running, and sharing flexible learning agents.
 
-AgentOS proposes a standard minimal architecture for a learning agent, and includes an API and example agent implementations for developers. The benefits of standard agent-related abstractions include:
+AgentOS is a **command line interface and Python developer API** for building,
+running, and sharing flexible learning agents.
 
-  * It is easier and faster to build agents since creators can focus on what is important to them without having to rewrite the parts that are less interesting but necessary in all agents (e.g., code to manage long running processes, parallelism, etc.).
-  * A simple open standard makes it easier to talk about agents, share agent code, and quickly understand agents created by others. These benefits are similar to those of the OpenAI Gym standard API for agent environments (`gym.Env <https://github.com/openai/gym/blob/master/gym/core.py>`_).
+AgentOS proposes a standard minimal architecture for a learning agent, and
+includes an API and example agent implementations for developers. The benefits
+of standard agent-related abstractions include:
 
-The best way to understand AgentOS is to use it, so let’s install agentos and write a simple agent in Python that behaves randomly. Installation is easy::
+  * It is easier and faster to build agents since creators can focus on what is
+    important to them without having to rewrite the parts that are less
+    interesting but necessary in all agents (e.g., code to manage long running
+    processes, parallelism, etc.).
+
+  * A simple open standard makes it easier to talk about agents, share agent
+    code, and quickly understand agents created by others. These benefits are
+    similar to those of the OpenAI Gym standard API for agent environments
+    (`gym.Env <https://github.com/openai/gym/blob/master/gym/core.py>`_).
+
+The best way to understand AgentOS is to use it, so let’s install agentos and
+write a simple agent in Python that behaves randomly. Installation is easy::
 
   $ pip install agentos
   $ pip install gym  # AgentOS uses OpenAI Gym's Environment abstraction.
@@ -24,13 +36,17 @@ Writing a trivial agent is also easy::
           print(f"Took a random step, done = {done}.")
           return done
 
-That’s it. Only one function is required to create an agent: ``advance()``. It takes no arguments, has access to the agent’s environment, and returns a boolean indicating if the agent is done.
+That’s it. Only one function is required to create an agent: ``advance()``. It
+takes no arguments, has access to the agent’s environment, and returns a
+boolean indicating if the agent is done.
 
 Next let’s open a Python shell::
 
   $ python
 
-... and then make an instance of our agent, pass its constructor an environment (or env) class that the agent will interact with, and have the agent advance (i.e., take one step of action) in that environment::
+... and then make an instance of our agent, pass its constructor an environment
+(or env) class that the agent will interact with, and have the agent advance
+(i.e., take one step of action) in that environment::
 
   >>> from simple_agent import SimpleAgent
   >>> from gym.envs.classic_control import CartPoleEnv
@@ -39,7 +55,9 @@ Next let’s open a Python shell::
   Took a random step, done = False.
   False
 
-The return value of ``False`` indicates that the agent is not yet “done”. Notice that in this code we are using an OpenAI gym environment (more about that below).
+The return value of ``False`` indicates that the agent is not yet “done”.
+Notice that in this code we are using an OpenAI gym environment (more about
+that below).
 
 Let’s continue running our agent using a while loop until it is done::
 
@@ -51,9 +69,12 @@ Let’s continue running our agent using a while loop until it is done::
   Took a random step, done = False.
   Took a random step, done = True.
 
-The number of steps that the agent takes before being done is random since its behavior is random (also the environment has randomness in it).
+The number of steps that the agent takes before being done is random since its
+behavior is random (also the environment has randomness in it).
 
-Now, instead of writing our own while loop, let’s run the agent in a Python Thread using a convenience function that AgentOS provides which serves as an Agent Runner::
+Now, instead of writing our own while loop, let’s run the agent in a Python
+Thread using a convenience function that AgentOS provides which serves as an
+Agent Runner::
 
   >>> agentos.run_agent(SimpleAgent, CartPoleEnv)
   Took a random step, done = False.
@@ -69,7 +90,8 @@ Or we can run the agent via the AgentOS CLI::
   Took a random step, done = False.
   Took a random step, done = True.
 
-As an alternative to using our custom agent above, let’s go back into the Python shell we opened above and use AgentOS’s RandomAgent::
+As an alternative to using our custom agent above, let’s go back into the
+Python shell we opened above and use AgentOS’s RandomAgent::
 
   >>> from agentos.agents import RandomAgent
   >>> from gym.envs.classic_control import CartPoleEnv
@@ -79,14 +101,39 @@ As an alternative to using our custom agent above, let’s go back into the Pyth
   Took a random step, done = False.
   Took a random step, done = True.
 
-So far, we created and ran an agent, but what is an agent? Colloquially speaking, it is an entity that can do things in its environment. In our examples above, the agent is interacting with an instance of a simple physics simulator provided by OpenAI Gym called `CartPole <https://github.com/openai/gym/blob/master/gym/envs/classic_control/cartpole.py>`_  (if you're not familiar with gym, learn more about it `here <https://gym.openai.com/>`_). In this environment, or world, the agent is trying to balance a pole on a cart by nudging the cart to the left or right. Because we made her a ``RandomAgent``, she is flipping a fair coin at each timestep to decide which way to nudge the cart.
+So far, we created and ran an agent, but what is an agent? Colloquially
+speaking, it is an entity that can do things in its environment. In our
+examples above, the agent is interacting with an instance of a simple physics
+simulator provided by OpenAI Gym called `CartPole
+<https://github.com/openai/gym/blob/master/gym/envs/classic_control/cartpole.py>`_
+(if you're not familiar with gym, learn more about it `here
+<https://gym.openai.com/>`_). In this environment, or world, the agent is
+trying to balance a pole on a cart by nudging the cart to the left or right.
+Because we made her a ``RandomAgent``, she is flipping a fair coin at each
+timestep to decide which way to nudge the cart.
 
-We have essentially created a simplistic being with some virtual sensors and motors, and given her the ability to use them to interact with her world, making observations and taking random actions in it. That’s a start, but note that she’s not learning anything as she goes, nor behaving intelligently. Still, you can start to get a sense of how to compose an agent with AgentOS.
+We have essentially created a simplistic being with some virtual sensors and
+motors, and given her the ability to use them to interact with her world,
+making observations and taking random actions in it. That’s a start, but note
+that she’s not learning anything as she goes, nor behaving intelligently.
+Still, you can start to get a sense of how to compose an agent with AgentOS.
 
-In this simple example, you have interacted with some of AgentOS’s core abstractions:
+In this simple example, you have interacted with some of AgentOS’s core
+abstractions:
 
-  * **Environment** - A stateful model of the world with a simple API. Used by an agent to make observations and take actions.
-  * **Agent** - Encapsulates a decision-making process (and memory) that uses observations to decide what actions to take, which obviously can impact what observations will come next. An agent is also responsible for learning, i.e., improving itself over time through experience, e.g., through RL algorithms.
-  * **Agent Runner** - an abstraction responsible for running an agent with a given environment.
+  * **Environment** - A stateful model of the world with a simple API. Used by
+    an agent to make observations and take actions.
 
-If you’re familiar with reinforcement learning (RL), both the environment and agent concepts in AgentOS are derived from RL (more on this in :doc:`/architecture_and_design`).
+  * **Agent** - Encapsulates a decision-making process (and memory) that uses
+    observations to decide what actions to take, which obviously can impact
+    what observations will come next. An agent is also responsible for
+    learning, i.e., improving itself over time through experience, e.g.,
+    through RL algorithms.
+
+  * **Agent Runner** - an abstraction responsible for running an agent with a
+    given environment.
+
+
+If you’re familiar with reinforcement learning (RL), both the environment and
+agent concepts in AgentOS are derived from RL (more on this in
+:doc:`/architecture_and_design`).


### PR DESCRIPTION
As proposed in PR #14, I think this makes diffs easier to read (see, for example, 4ae0608).  I built the docs locally and manually compared them to the live docs to confirm this didn't affect styling.

Also, capitalized Python in index.rst again 😄 