### PR TITLE
Add missing language_data.js file to enable RTD theme search

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -64,6 +64,10 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_js_files = [
+    'language_data.js',
+]
+
 #html_additional_pages = {
 #  'homepage': 'homepage.html',
 #}


### PR DESCRIPTION
The maintainable way to fix search: include the missing JS file via `conf.py`

See related discussions:

* [StackOverflow]( https://stackoverflow.com/questions/52474177/read-the-docs-search-broken)
* [GitHub issue in Sphinx project](https://github.com/sphinx-doc/sphinx/issues/5460)
* [Example Fix](https://github.com/HangfireIO/Hangfire.Documentation/commit/de122cc40a3df6c387bd9b6bff0aa6d14ab66f80)