### PR TITLE
Update requirements for building docs and add helper scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,17 +51,19 @@ To run tests::
 Building Documentation / Agentos.org Website
 --------------------------------------------
 
-The documentation is in the ``docs`` direcory and written in `ReStructuredText <https://docutils.sourceforge.io/rst.html>`_.
-To build the docs you'll need to use `Sphinx <https://www.sphinx-doc.org>`_:::
+The documentation is in the ``docs`` directory and written in
+`ReStructuredText <https://docutils.sourceforge.io/rst.html>`_.
+To build the docs you'll need to use
+`Sphinx <https://www.sphinx-doc.org>`_:::
 
   pip install -r documentation/requirements.txt
-  sphinx-build docs docs/_build  # also checkout the pip package sphinx-autobuild
+  ./documentation/scripts/build-docs
   # Open and inspect docs/_build/index.html in your broswer.
 
 `agentos.org <https://agentos.org>`_ is a github.io website where the AgentOS
 docs are hosted.  To publish updated docs to agentos.org, build the docs and
 put the output into the ``docs`` directory and the ``docs/<current_version>``
-diretories in the ``website`` branch. Those changes will become live at
+directories in the ``website`` branch. Those changes will become live at
 agentos.org automatically.
 
 Assuming you have local branches tracking both the ``master`` and ``website``

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -2,3 +2,5 @@ Sphinx==3.4.1
 sphinx-click==2.5.0
 sphinx_rtd_theme==0.5.1
 click>=7.0 # when updating, also update in ../setup.py
+gym==0.18.0
+mlflow==1.13.1

--- a/documentation/scripts/build-docs
+++ b/documentation/scripts/build-docs
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+# One liner to find script dir https://stackoverflow.com/a/246128
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source "$SCRIPT_DIR/common"
+
+PYTHONPATH="$ROOT_DIR" sphinx-build "$DOCUMENTATION_DIR" "$BUILD_DIR"
+
+echo
+echo "Docs built in $BUILD_DIR"

--- a/documentation/scripts/clean-docs
+++ b/documentation/scripts/clean-docs
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+# One liner to find script dir https://stackoverflow.com/a/246128
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source "$SCRIPT_DIR/common"
+
+rm -rf "$BUILD_DIR"
+
+echo "Removed docs in $BUILD_DIR"

--- a/documentation/scripts/common
+++ b/documentation/scripts/common
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+
+# One liner to find script dir https://stackoverflow.com/a/246128
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Variables shared between other scripts
+DOCUMENTATION_DIR="$SCRIPT_DIR/.."
+ROOT_DIR="$SCRIPT_DIR/../.."
+BUILD_DIR="$DOCUMENTATION_DIR/_build"


### PR DESCRIPTION
When I merged in upstream, I realized I could no longer build the docs.  Turns out I needed to:

* Add the `agentos` module to my `PYTHONPATH`, and
* Install `gym` and `mlflow`

Presumably sphinx is trying to do something like import these modules (and their dependencies) to get at their docstrings.

Not sure how you want to handle this, but adding those two packages to the `documentation/requirements.txt` is one way!

Also, added some convenience scripts for building and cleaning:

* `./documentation/scripts/build-docs`
* `./documentation/scripts/clean-docs`