### PR TITLE
Use os.sep and os.pardir

### DIFF
--- a/documentation/build_docs.py
+++ b/documentation/build_docs.py
@@ -11,15 +11,22 @@ import os
 from subprocess import Popen
 
 docs_dir = os.path.dirname(os.path.abspath(__file__))
+version_file = os.path.join(docs_dir, os.pardir, 'agentos', 'version.py')
+loaded = SourceFileLoader('agentos.version', version_file).load_module()
+version = loaded.VERSION
 
-version = SourceFileLoader(
-    'agentos.version', os.path.join(docs_dir, '..', 'agentos', 'version.py')).load_module().VERSION
-Popen(["sphinx-build", docs_dir, f"{docs_dir}/../docs/{version}"]).wait()
+build_dir = os.path.normpath(os.path.join(docs_dir, os.pardir, "docs"))
+versioned_build_dir = os.path.join(build_dir, f"{version}")
 
-os.chdir(f"{docs_dir}/../docs")
+Popen(["sphinx-build", docs_dir, versioned_build_dir]).wait()
+
+os.chdir(build_dir)
+
 try:
     os.remove(f"latest")
 except FileNotFoundError:
     print('Latest symlink not found')
+
 os.symlink(version, "latest", target_is_directory=True)
-print(f"Created symbolic link docs/latest pointing to docs/{version}")
+print(f"Created symbolic link {build_dir}{os.sep}latest "
+      f"pointing to {build_dir}{os.sep}{version}")

--- a/documentation/build_readme.py
+++ b/documentation/build_readme.py
@@ -11,25 +11,27 @@ To use::
 import os
 
 docs_dir = os.path.dirname(os.path.abspath(__file__))
-target_readme = f"{docs_dir}/../README.rst"
+target_readme = os.path.join(docs_dir, os.pardir, 'README.rst')
 
 with open(target_readme, "w") as readme_f:
     def include(src_file):
         with open(src_file, "r") as f:
             readme_f.write(f.read())
-
-
-    include(docs_dir + '/includes/intro.rst')
+    
+    intro_text = os.path.join(docs_dir, 'includes', 'intro.rst')
+    include(intro_text)
     readme_f.write("\n\nThe AgentOS docs are at `agentos.org "
                    "<https://agentos.org>`_.\n\n\n")
 
-    include(docs_dir + '/includes/install_and_try.rst')
+    install_text = os.path.join(docs_dir, 'includes', 'install_and_try.rst')
+    include(install_text)
     readme_f.write("\n\n")
 
-    include(docs_dir + '/includes/developing.rst')
+    developing_text = os.path.join(docs_dir, 'includes', 'developing.rst')
+    include(developing_text)
     readme_f.write("\n\n")
 
-    readme_f.write("----\n\n" +
-                   "*This README was compiled from the project " +
-                   "documentation via:*\n" +
-                   f"``python documentation/{os.path.basename(__file__)}``.")
+    readme_f.write("----\n\n"
+                   "*This README was compiled from the project "
+                   "documentation via:*\n``python "
+                   f"documentation{os.sep}{os.path.basename(__file__)}``.")


### PR DESCRIPTION
Minor updates to build_docs.py and build_readme.py that shouldn't change functionality:
* Use `os.sep` instead of `/`
* Use `os.pardir` instead of `..`
* Use `os.path.join` instead of format strings

Theoretically, should make these scripts more likely to run on windows (though, I haven't actually tested on windows)