### PR TITLE
Add scripts to format and lint code

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,6 +11,7 @@ sphinx_rtd_theme==0.5.1
 click>=7.0 # when updating, also update in ../setup.py
 
 # Tests requirements
+black==20.8b1
 cloudpickle==1.3.0  # gym 0.17.1 in setup.py requires cloudpickle<1.4.0,>=1.2.0
 flake8==3.8.3
 matplotlib==3.2.1

--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -1,0 +1,29 @@
+"""
+Run black code formatter on AgentOS Python files
+
+To use::
+
+  $ python documentation/format_code.py
+"""
+
+import os
+from subprocess import run
+from subprocess import PIPE
+
+from shared import root_dir
+from shared import traverse_tracked_files
+
+
+def format_file(path):
+    extension = os.path.splitext(path)[1]
+    if extension != ".py":
+        return
+    cmd = ["black", path]
+    out = run(cmd, stdout=PIPE).stdout.decode("utf-8")
+    if out:
+        print(path)
+        print(out)
+        print()
+
+
+traverse_tracked_files(root_dir, format_file)

--- a/scripts/lint_code.py
+++ b/scripts/lint_code.py
@@ -1,0 +1,29 @@
+"""
+Run flake8 linter on AgentOS Python files
+
+To use::
+
+  $ python scripts/lint_code.py
+"""
+
+import os
+from subprocess import run
+from subprocess import PIPE
+
+from shared import root_dir
+from shared import traverse_tracked_files
+
+
+def flake_file(path):
+    extension = os.path.splitext(path)[1]
+    if extension != ".py":
+        return
+    cmd = ["flake8", path]
+    out = run(cmd, stdout=PIPE).stdout.decode("utf-8")
+    if out:
+        print(path)
+        print(out)
+        print()
+
+
+traverse_tracked_files(root_dir, flake_file)

--- a/scripts/shared.py
+++ b/scripts/shared.py
@@ -1,0 +1,34 @@
+"""
+Lints AgentOS Python files
+
+To use::
+
+  $ python scripts/lint_code.py
+"""
+
+import os
+from subprocess import Popen
+from subprocess import DEVNULL
+
+scripts_dir = os.path.dirname(os.path.abspath(__file__))
+root_dir = os.path.normpath(os.path.join(scripts_dir, os.pardir))
+
+
+def is_git_tracked(file_path):
+    cmd = ["git", "ls-files", "--error-unmatch", file_path]
+    child = Popen(cmd, stdout=DEVNULL, stderr=DEVNULL)
+    child.wait()
+    return child.returncode == 0
+
+
+def traverse_tracked_files(path, action_fn):
+    if not is_git_tracked(path):
+        return
+
+    if os.path.isfile(path):
+        action_fn(path)
+
+    if os.path.isdir(path):
+        for item in os.listdir(path):
+            to_traverse = os.path.join(path, item)
+            traverse_tracked_files(to_traverse, action_fn)


### PR DESCRIPTION
Adds two Python scripts to automatically format and lint Python code.  These will specifically only run on Python files tracked by git (and not, for example, Python files in packages in a virtualenv you keep untracked in the git repo).

To format with black: `python scripts/format_code.py`

To lint with flake8: `python scripts/lint_code.py`

I specifically did **not**:
* Set up any particular rules for formatting and linting.  Let's figure out a reasonable configuration once this gets in (or we could just use defaults, which I think conform to the pep8 style guide)
* Run the formatter on the existing code.  Let's wait until we decide on how to configure the formatter.

Per our conversation earlier, the [black repo](https://github.com/psf/black) has 19k stars and 1k forks which makes me think it's reasonably popular in the community.
