### PR TITLE
Separate format and lint github actions

### DIFF
--- a/.github/workflows/run-format.yml
+++ b/.github/workflows/run-format.yml
@@ -1,0 +1,27 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Format Python code
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  run_format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r dev-requirements.txt
+      - name: Lint with flake8
+        run: |
+          python scripts/format_code.py --check
+

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -1,0 +1,26 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Lint Python code
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  run_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r dev-requirements.txt
+      - name: Lint with flake8
+        run: |
+          python scripts/lint_code.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   run_pytest:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -18,31 +17,34 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r dev-requirements.txt
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 agentos --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        python scripts/lint_code.py
-    - name: Install agentos
-      run: |
-        pip install -e .
-    - name: Test with pytest on linux or macos
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-      run: |
-        export MLFLOW_CONDA_HOME=$CONDA
-        pytest --durations=0
-    - name: Test with pytest on Windows
-      if: matrix.os == 'windows-latest'
-      run: |
-        $ENV:MLFLOW_CONDA_HOME=$ENV:CONDA
-        pytest --durations=0
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r dev-requirements.txt
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 agentos --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          python scripts/lint_code.py
+      - name: Ensure all Python files are properly formatted
+        run: |
+          python scripts/format_code.py --check
+      - name: Install agentos
+        run: |
+          pip install -e .
+      - name: Test with pytest on linux or macos
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        run: |
+          export MLFLOW_CONDA_HOME=$CONDA
+          pytest --durations=0
+      - name: Test with pytest on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          $ENV:MLFLOW_CONDA_HOME=$ENV:CONDA
+          pytest --durations=0

--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -3,23 +3,36 @@ Run black code formatter on AgentOS Python files
 
 To use::
 
-  $ python documentation/format_code.py
+  # Format all code
+  $ python scripts/format_code.py
+
+  # Print files that will be formatted, but don't actually format
+  $ python scripts/format_code.py --check
 """
 
 import os
+import sys
 from subprocess import run
 from subprocess import PIPE
+from subprocess import STDOUT
 
 from shared import root_dir
 from shared import traverse_tracked_files
 
+returncode = 0
+
 
 def format_file(path):
+    global returncode
     extension = os.path.splitext(path)[1]
     if extension != ".py":
         return
     cmd = ["black", "--line-length=79", path]
-    out = run(cmd, stdout=PIPE).stdout.decode("utf-8")
+    if len(sys.argv) > 1 and sys.argv[1] == "--check":
+        cmd.append("--check")
+    result = run(cmd, stdout=PIPE, stderr=STDOUT)
+    returncode = returncode | result.returncode
+    out = result.stdout.decode("utf-8")
     if out:
         print(path)
         print(out)
@@ -27,3 +40,4 @@ def format_file(path):
 
 
 traverse_tracked_files(root_dir, format_file)
+sys.exit(returncode)


### PR DESCRIPTION
Breaks out the format and lint github actions into their own flows so the tests will still run even if black or flake8 raises an issue.