### PR TITLE
Move documentation build scripts and fix link to github tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Key features include:
   * Reuse of OpenAI's Gym Environment abstraction.
 
 .. image:: https://github.com/agentos-project/agentos/workflows/Tests%20on%20master/badge.svg
-  :target: https://github.com/agentos-project/agentos/actions)
+  :target: https://github.com/agentos-project/agentos/actions
   :alt: Test Status Indicator
 
 AgentOS is beta software, APIs and overall architecture are likely to change

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ install the dev requirements::
 
 Then use the build script::
 
-  python documentation/build_docs.py
+  python scripts/build_docs.py
 
 Or to build the docs manually yourself (e.g., to control where output goes)::
 
@@ -107,7 +107,7 @@ committed in the ``master`` branch, your workflow might look similar to::
 
   git checkout website
   git merge master
-  python documentation/build_docs.py
+  python scripts/build_docs.py
   git add docs
   git commit -m "push updated docs to website"
   git push
@@ -116,13 +116,13 @@ committed in the ``master`` branch, your workflow might look similar to::
 Building README.rst
 ===================
 The main project ``README.rst`` is built via the script
-``python documentation/build_readme.py``, which re-uses sections of
+``python scripts/build_readme.py``, which re-uses sections of
 documentation. This avoids duplication of efforts and lowers the chances
 that a developer will forget to update one or the either of the README or
 the docs.
 
 To update ``README.rst``, first familiarize yourself with its build script
-``documentation/build_readme.py``. There you can see which sections of
+``scripts/build_readme.py``. There you can see which sections of
 documentation are included in ``README.rst``, plus some text that is manually
 inserted directly into ``README.rst`` (e.g., the footer).
 

--- a/documentation/includes/developing.rst
+++ b/documentation/includes/developing.rst
@@ -32,7 +32,7 @@ install the dev requirements::
 
 Then use the build script::
 
-  python documentation/build_docs.py
+  python scripts/build_docs.py
 
 Or to build the docs manually yourself (e.g., to control where output goes)::
 
@@ -54,7 +54,7 @@ committed in the ``master`` branch, your workflow might look similar to::
 
   git checkout website
   git merge master
-  python documentation/build_docs.py
+  python scripts/build_docs.py
   git add docs
   git commit -m "push updated docs to website"
   git push
@@ -63,13 +63,13 @@ committed in the ``master`` branch, your workflow might look similar to::
 Building README.rst
 ===================
 The main project ``README.rst`` is built via the script
-``python documentation/build_readme.py``, which re-uses sections of
+``python scripts/build_readme.py``, which re-uses sections of
 documentation. This avoids duplication of efforts and lowers the chances
 that a developer will forget to update one or the either of the README or
 the docs.
 
 To update ``README.rst``, first familiarize yourself with its build script
-``documentation/build_readme.py``. There you can see which sections of
+``scripts/build_readme.py``. There you can see which sections of
 documentation are included in ``README.rst``, plus some text that is manually
 inserted directly into ``README.rst`` (e.g., the footer).
 

--- a/documentation/includes/intro.rst
+++ b/documentation/includes/intro.rst
@@ -18,7 +18,7 @@ Key features include:
   * Reuse of OpenAI's Gym Environment abstraction.
 
 .. image:: https://github.com/agentos-project/agentos/workflows/Tests%20on%20master/badge.svg
-  :target: https://github.com/agentos-project/agentos/actions)
+  :target: https://github.com/agentos-project/agentos/actions
   :alt: Test Status Indicator
 
 AgentOS is beta software, APIs and overall architecture are likely to change

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -3,20 +3,24 @@ Build the AgentOS documentation.
 
 To use::
 
-  $ python documentation/build_docs.py
+  $ python scripts/build_docs.py
 """
 
 from importlib.machinery import SourceFileLoader
 import os
 from subprocess import Popen
 
-docs_dir = os.path.dirname(os.path.abspath(__file__))
-version_file = os.path.join(docs_dir, os.pardir, "agentos", "version.py")
+scripts_dir = os.path.dirname(os.path.abspath(__file__))
+version_file = os.path.join(scripts_dir, os.pardir, "agentos", "version.py")
 loaded = SourceFileLoader("agentos.version", version_file).load_module()
 version = loaded.VERSION
 
-build_dir = os.path.normpath(os.path.join(docs_dir, os.pardir, "docs"))
+build_dir = os.path.normpath(os.path.join(scripts_dir, os.pardir, "docs"))
 versioned_build_dir = os.path.join(build_dir, f"{version}")
+
+docs_dir = os.path.normpath(
+    os.path.join(scripts_dir, os.pardir, "documentation")
+)
 
 Popen(["sphinx-build", docs_dir, versioned_build_dir]).wait()
 

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -5,34 +5,26 @@ To use::
 
   $ python scripts/build_docs.py
 """
-
-from importlib.machinery import SourceFileLoader
 import os
 from subprocess import Popen
 
-scripts_dir = os.path.dirname(os.path.abspath(__file__))
-version_file = os.path.join(scripts_dir, os.pardir, "agentos", "version.py")
-loaded = SourceFileLoader("agentos.version", version_file).load_module()
-version = loaded.VERSION
+import agentos
+from shared import docs_dir
+from shared import docs_build_dir
 
-build_dir = os.path.normpath(os.path.join(scripts_dir, os.pardir, "docs"))
-versioned_build_dir = os.path.join(build_dir, f"{version}")
-
-docs_dir = os.path.normpath(
-    os.path.join(scripts_dir, os.pardir, "documentation")
-)
+versioned_build_dir = os.path.join(docs_build_dir, f"{agentos.__version__}")
 
 Popen(["sphinx-build", docs_dir, versioned_build_dir]).wait()
 
-os.chdir(build_dir)
+os.chdir(docs_build_dir)
 
 try:
     os.remove("latest")
 except FileNotFoundError:
     print("Latest symlink not found")
 
-os.symlink(version, "latest", target_is_directory=True)
+os.symlink(agentos.__version__, "latest", target_is_directory=True)
 print(
-    f"Created symbolic link {build_dir}{os.sep}latest "
-    f"pointing to {build_dir}{os.sep}{version}"
+    f"Created symbolic link {docs_build_dir}{os.sep}latest "
+    f"pointing to {docs_build_dir}{os.sep}{agentos.__version__}"
 )

--- a/scripts/build_readme.py
+++ b/scripts/build_readme.py
@@ -5,12 +5,13 @@ of efforts and fewer chances for bugs.
 
 To use::
 
-  python documentation/build_readme.py
+  python scripts/build_readme.py
 """
 
 import os
 
-docs_dir = os.path.dirname(os.path.abspath(__file__))
+scripts_dir = os.path.dirname(os.path.abspath(__file__))
+docs_dir = os.path.join(scripts_dir, os.pardir, "documentation")
 target_readme = os.path.join(docs_dir, os.pardir, "README.rst")
 
 with open(target_readme, "w") as readme_f:

--- a/scripts/build_readme.py
+++ b/scripts/build_readme.py
@@ -10,8 +10,8 @@ To use::
 
 import os
 
-scripts_dir = os.path.dirname(os.path.abspath(__file__))
-docs_dir = os.path.join(scripts_dir, os.pardir, "documentation")
+from shared import docs_dir
+
 target_readme = os.path.join(docs_dir, os.pardir, "README.rst")
 
 with open(target_readme, "w") as readme_f:

--- a/scripts/shared.py
+++ b/scripts/shared.py
@@ -12,6 +12,8 @@ from subprocess import DEVNULL
 
 scripts_dir = os.path.dirname(os.path.abspath(__file__))
 root_dir = os.path.normpath(os.path.join(scripts_dir, os.pardir))
+docs_dir = os.path.join(root_dir, "documentation")
+docs_build_dir = os.path.join(root_dir, "docs")
 
 
 def is_git_tracked(file_path):


### PR DESCRIPTION
* Found the link on the github testing badge was broken so fixed that in b1ff04a

![agentosbadge](https://user-images.githubusercontent.com/25208102/105611721-cb61cc00-5d6b-11eb-889b-80627e9def42.png)


* Decided to knock out https://github.com/agentos-project/agentos/issues/48 while I was in there (although, I'll hold off on fixing "good first issues" in the future)
