### PR TITLE
Bump version to 0.1.0-alpha & fix typo in docs

### DIFF
--- a/agentos/version.py
+++ b/agentos/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.7"
+VERSION = "0.1.0-alpha"

--- a/documentation/programming_agents.rst
+++ b/documentation/programming_agents.rst
@@ -125,4 +125,4 @@ different purposes, but rollouts always consist of the same basic structure.
 
 Since rollouts are used frequently and have a standard structure, AgentOS
 includes the ``agentos.core.rollout()`` utility function, but **note that the
-psuedocode above is a simplified version of ``agentos.core.rollout()``.**
+psuedocode above is a simplified version of** ``agentos.core.rollout()``.


### PR DESCRIPTION
Per the release process I'm tracking in #103, this updates the working version of the `master` branch to have the "-alpha" suffix.

Also fixes a small bug I noticed in the docs while reviewing them before publishing them.