### PR TITLE
update docs/readme based on lessons learned cutting release 0.0.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,8 @@ Then, create and run your first Agent::
   agentos init
   agentos run
 
-This type of agent is called an :doc:`Agent Directory <../agent_directories>`. To see more complex
-agents, look at example agents in the `example_agents
+This type of agent is called an `Agent Directory <../agent_directories>`. To
+see more complex agents, look at example agents in the `example_agents
 <https://github.com/agentos-project/agentos/tree/master/example_agents>`_
 directory of the project source code.
 
@@ -195,6 +195,16 @@ Releasing
 
 Here are the steps for releasing AgentOS:
 
+#. Build and check the distribution artifacts for the release by running::
+
+   pip install -r dev-requirements.txt
+   python setup.py sdist --formats=gztar,zip bdist_wheel
+   twine check dist/*
+
+   This will create a `wheel file <https://wheel.readthedocs.io/en/stable/>`_
+   as well as tar.gz and zip source distribution files, and catch any blockers
+   that PyPI would raise at upload time. Fix any errors before proceeding.
+
 #. Create a release pull request (PR) that:
 
    * Removes "-alpha" suffix from the version number in ``agentos/version.py``.
@@ -215,10 +225,9 @@ Here are the steps for releasing AgentOS:
 #. Push the release to PyPI (see `Pushing Releases to PyPI`_).
 
 #. Create a `github release
-   <https://github.com/agentos-project/agentos/releases>`_ that includes zips
-   and tarzips of `wheel files <https://wheel.readthedocs.io/en/stable/>`_
-   and source code (which you can generate using ``python setup.py sdist
-   --formats=gztar,zip bdist_wheel`` and then manually upload to the release).
+   <https://github.com/agentos-project/agentos/releases>`_ and upload the
+   tar.gz and zip source code distribution files. This will create a git tag.
+   For the tag name, use "vX.Y.Z" (e.g. v0.1.0).
 
 
 Pushing Releases to PyPI
@@ -229,8 +238,10 @@ push a release to PyPI, you can approximately follow `these python.org
 instructions <https://packaging.python.org/tutorials/packaging-projects/>`_,
 which will probably look something like::
 
-  pip install setuptools wheel twine
-  python setup.py sdist --formats=gztar,zip bdist_wheel
+  pip install -r dev-requirements.txt
+  rm -rf dist
+  python setup.py sdist --formats=gztar bdist_wheel
+  twine check dist/*
   twine upload dist/*
 
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,3 +17,8 @@ cloudpickle==1.3.0  # gym 0.17.1 in setup.py requires cloudpickle<1.4.0,>=1.2.0
 flake8==3.8.3
 pytest==3.2.1
 pytest-virtualenv==1.7.0
+
+# Releasing requirements
+setuptools==51.0.0
+wheel==0.36.1
+twine==3.3.0

--- a/documentation/includes/developing.rst
+++ b/documentation/includes/developing.rst
@@ -140,6 +140,16 @@ Releasing
 
 Here are the steps for releasing AgentOS:
 
+#. Build and check the distribution artifacts for the release by running::
+
+   pip install -r dev-requirements.txt
+   python setup.py sdist --formats=gztar,zip bdist_wheel
+   twine check dist/*
+
+   This will create a `wheel file <https://wheel.readthedocs.io/en/stable/>`_
+   as well as tar.gz and zip source distribution files, and catch any blockers
+   that PyPI would raise at upload time. Fix any errors before proceeding.
+
 #. Create a release pull request (PR) that:
 
    * Removes "-alpha" suffix from the version number in ``agentos/version.py``.
@@ -160,10 +170,9 @@ Here are the steps for releasing AgentOS:
 #. Push the release to PyPI (see `Pushing Releases to PyPI`_).
 
 #. Create a `github release
-   <https://github.com/agentos-project/agentos/releases>`_ that includes zips
-   and tarzips of `wheel files <https://wheel.readthedocs.io/en/stable/>`_
-   and source code (which you can generate using ``python setup.py sdist
-   --formats=gztar,zip bdist_wheel`` and then manually upload to the release).
+   <https://github.com/agentos-project/agentos/releases>`_ and upload the
+   tar.gz and zip source code distribution files. This will create a git tag.
+   For the tag name, use "vX.Y.Z" (e.g. v0.1.0).
 
 
 Pushing Releases to PyPI
@@ -174,6 +183,8 @@ push a release to PyPI, you can approximately follow `these python.org
 instructions <https://packaging.python.org/tutorials/packaging-projects/>`_,
 which will probably look something like::
 
-  pip install setuptools wheel twine
-  python setup.py sdist --formats=gztar,zip bdist_wheel
+  pip install -r dev-requirements.txt
+  rm -rf dist
+  python setup.py sdist --formats=gztar bdist_wheel
+  twine check dist/*
   twine upload dist/*

--- a/documentation/includes/install_and_try.rst
+++ b/documentation/includes/install_and_try.rst
@@ -17,7 +17,7 @@ Then, create and run your first Agent::
   agentos init
   agentos run
 
-This type of agent is called an :doc:`Agent Directory <../agent_directories>`. To see more complex
-agents, look at example agents in the `example_agents
+This type of agent is called an `Agent Directory <../agent_directories>`. To
+see more complex agents, look at example agents in the `example_agents
 <https://github.com/agentos-project/agentos/tree/master/example_agents>`_
 directory of the project source code.


### PR DESCRIPTION
This partially addresses #67 by just removing the offending link (since it was causing PyPI upload to fail while trying to push release 0.0.7 to PyPI). It does not guarantee that we won't accidentally use Sphinx-specific references that don't make sense in the README.