### PR TITLE
copy design docs and updated readme from design_docs repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ process is to:
 * Allow developers to think through a design, and
 * Allow stakeholders to give feedback
 
-...**before** development begins.
+...before development begins.
 
 If you'd like to propose a feature, please follow the procedure found in the
 `design_docs README <documentation/design_docs/README.rst>`_.  You can also

--- a/README.rst
+++ b/README.rst
@@ -86,19 +86,18 @@ To contribute to AgentOS, the general workflow is as follows:
 Proposing Features
 ==================
 
-For new features and other big chunks of work, AgentOS maintains a `repo of
-design documents <https://github.com/agentos-project/design_docs>`_.  The goal
-of these design documents is to:
+For new features and other big chunks of work, AgentOS uses a design process
+centered around design proposals, discussions, and design docs. The goal of the
+process is to:
 
 * Allow developers to think through a design, and
 * Allow stakeholders to give feedback
 
-before development begins.
+...**before** development begins.
 
 If you'd like to propose a feature, please follow the procedure found in the
-`design_docs README
-<https://github.com/agentos-project/design_docs/blob/main/README.rst>`_.  You
-can also browse other design docs in the repo to get a feel for the general
+`design_docs README <documentation/design_docs/README.rst>`_.  You can also
+browse existing design docs in the folder to get a feel for the general
 content and style.
 
 

--- a/documentation/design_docs/README.rst
+++ b/documentation/design_docs/README.rst
@@ -1,0 +1,62 @@
+===================
+AgentOS Design Docs
+===================
+
+This folder holds design documents and proposals for AgentOS internals.
+
+
+============
+Contributing
+============
+
+If you'd like to contribute a design document or proposal, please:
+
+* Start a new
+  [Discussion](https://github.com/agentos-project/agentos/discussions)
+  under the "Ideas" category.
+
+* Iterate on the idea with community members via comments in that Discussion.
+
+* When you have support by the committers, the discussion is migrated from the
+  "Ideas" category to the "Designs" category by changing the category in the
+  original discussion (or, if it makes more sense a new discussion can be
+  created that references the original), and...
+
+    * For smaller features, the body text of the discussion thread acts as the
+      design doc, reviews happen via comments in the discussion thread and
+      feedback is merged into the "doc" by editing the original discussion text
+      (in this scenario, version history will not be captured).
+
+    * For large designs, a document written in `reStructuredText
+      <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
+      may be created in this (the `design_docs`) folder. If it is owned by a
+      committer, then they may edit it at will without using a fork or PRs. This
+      keeps the design process lightweight while capturing revision history of the
+      document. You might also find the `reStructuredText Quick Reference
+      <https://docutils.sourceforge.io/docs/user/rst/quickref.html>`_ useful.
+
+
+==================
+Recommended Format
+==================
+
+Please include the following sections and items in your design document:
+
+* **Abstract** - A brief paragraph summary of the design
+
+* **Rationale** - The reason why this feature is important or useful
+
+* **Demo** - A "demo" of what the feature will look like after implementation.
+  This can contain pseudocode or command line examples.
+
+* **Work items** - This is a set of items required to accomplish the proposed
+  design.
+
+* **FAQ** - Frequently asked questions.  Especially useful to address questions
+  from your reviewer.
+
+* **Open Questions** - A section to record things that should be investigated or
+  may change as the design gets implemented.
+
+* Links to any pull requests related to the document so comment history and
+  debate can be discovered.

--- a/documentation/design_docs/README.rst
+++ b/documentation/design_docs/README.rst
@@ -12,7 +12,7 @@ Contributing
 If you'd like to contribute a design document or proposal, please:
 
 * Start a new
-  [Discussion](https://github.com/agentos-project/agentos/discussions)
+  `Discussion <https://github.com/agentos-project/agentos/discussions>`_
   under the "Ideas" category.
 
 * Iterate on the idea with community members via comments in that Discussion.
@@ -22,18 +22,18 @@ If you'd like to contribute a design document or proposal, please:
   original discussion (or, if it makes more sense a new discussion can be
   created that references the original), and...
 
-    * For smaller features, the body text of the discussion thread acts as the
-      design doc, reviews happen via comments in the discussion thread and
-      feedback is merged into the "doc" by editing the original discussion text
-      (in this scenario, version history will not be captured).
+  * For smaller features, the body text of the discussion thread acts as the
+    design doc, reviews happen via comments in the discussion thread and
+    feedback is merged into the "doc" by editing the original discussion text
+    (in this scenario, version history will not be captured).
 
-    * For large designs, a document written in `reStructuredText
-      <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
-      may be created in this (the `design_docs`) folder. If it is owned by a
-      committer, then they may edit it at will without using a fork or PRs. This
-      keeps the design process lightweight while capturing revision history of the
-      document. You might also find the `reStructuredText Quick Reference
-      <https://docutils.sourceforge.io/docs/user/rst/quickref.html>`_ useful.
+  * For large designs, a document written in `reStructuredText
+    <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
+    may be created in this (the `design_docs`) folder. If it is owned by a
+    committer, then they may edit it at will without using a fork or PRs. This
+    keeps the design process lightweight while capturing revision history of the
+    document. You might also find the `reStructuredText Quick Reference
+    <https://docutils.sourceforge.io/docs/user/rst/quickref.html>`_ useful.
 
 
 ==================

--- a/documentation/design_docs/abstractions.rst
+++ b/documentation/design_docs/abstractions.rst
@@ -1,0 +1,358 @@
+=========================
+AgentOS Core Abstractions
+=========================
+
+Current Version: v4
+
+See `Revision History`_ for additional discussion.
+
+
+Abstract
+========
+
+This document proposes the core abstractions of the AgentOS system.  These
+abstractions are:
+
+* **Environment** - A representation of the world in which the agent operates.
+  An agent takes actions within an environment, and these actions can
+  potentially affect the environment's state (and thus the agent's
+  observation).
+
+* **Policy** - Encapsulates the agent's decision making process.  The policy
+  chooses an action given a set of observations.  It also provides facilities
+  for improving itself as the agent gains experience.
+
+* **Agent** - The agent contains a policy.  It performs actions based on its
+  policy within the environment so that it can learn how to maximize reward.
+
+Rationale
+=========
+
+AgentOS aims to define a clean set of abstractions that will be familiar to a
+researcher in the reinforcement learning (RL) space while also being
+approachable to a technically educated generalist like a software engineer.
+The proposed set of abstractions hew closely to the standard academic
+presentation of RL while allowing for composition and reuse at the software
+level.
+
+
+User Stories
+============
+
+RL newbie trying to learn
+-------------------------
+
+As a software programmer and newbie to RL/AI, I want learn RL by looking at
+documentation and code examples and I want to start making my own agents by
+composing existing algorithms, environments, etc. I am interested in using both
+the AgentOS CLI and the Python API as I learn.
+
+
+Agent developer using Python
+----------------------------
+
+As an agent developer, I want to write my own agents, policies, environments,
+and other components from scratch in Python and manipulate them entirely via
+the command line.
+
+
+Agent user running somebody elses agent
+---------------------------------------
+
+As a researcher on a conference program committee reviewing RL papers, I want
+to clone my own copy of an agent from a paper, run it, and inspect its parts.
+Ideally I would like it to conform to known APIs so that I can a priori have
+some idea of what different parts do.
+
+Agent developer incorporating RL into their tech stack
+------------------------------------------------------
+
+As a developer incorporating RL into my tech stack, I need to run experiments
+with different agent configurations to determine what flavor of RL is best
+suited to the business problem my work is addressing. Being able to
+programmatically interact with agents allows me to run these experiments as
+well as train and deploy my agent in a reproducible way.
+
+
+Core Abstractions
+=================
+
+This section will present sample code for each of the core abstractions as
+well as discuss implications and future directions.
+
+Environment
+-----------
+
+An environment will conform to `OpenAI's gym <https://gym.openai.com/>`_ API.
+Core methods are:
+
+* ``step(action) -> (observation, done, reward, info)``: This takes one action
+  within the environment and transitions to a new state.
+
+* ``reset() -> observation``: This resets the environment to an initial state.
+
+Here is an example environment that represents a 1-dimensional corridor that
+the agent must learn to walk down::
+
+    import gym
+
+    class Corridor(gym.Env):
+
+        def __init__(self):
+            self.length = 10
+            self.action_space = gym.spaces.Discrete(2)
+            self.observation_space = gym.spaces.Discrete(self.length + 1)
+            self.reset()
+
+        def step(self, action):
+            assert action in [0, 1]
+            if action == 0:
+                self.position = max(self.position - 1, 0)
+            else:
+                self.position = min(self.position + 1, self.length)
+            return (self.position, -1, self.done, {})
+
+        def done(self):
+            return self.position >= self.length
+
+        def reset(self):
+            self.position = 0
+            return self.position
+
+Policy
+------
+
+A policy encapsulates an agent's decision making process.  A policy will often
+be backed by some sort of stateful storage (e.g. a table or a serialized
+neural net).  Eventually, AgentOS will provide ability to easily share
+policies (including their state) between agents.
+
+A policy must provide the following three methods:
+
+* ``decide(self, obs) -> action``: Takes the agent's current observation and
+  returns the next action the agent should take.
+
+* ``improve(self, **kwargs) -> None``: Updates the agent's policy based upon
+  experience (e.g. training the DQN backing the policy via gradient descent).
+
+* ``reset(self) -> None``: Dumps any stateful part of the policy so that the
+  agent can restart learning from scratch.
+
+
+An example policy class might look like the following::
+
+    import agentos
+
+    class DeepQNetwork(agentos.Policy):
+        def decide(self, obs):
+            action_probabilites = self.nn(obs)
+            return random.weighted_choose(action_probabilities)
+
+        def improve(self, environment_class):
+            rollouts = agentos.do_rollouts(self, environment_class)
+            advantaged_rollouts = calculate_advantage(rollouts)
+            self.nn.train(advantaged_rollouts)
+
+        def reset(self):
+            self.nn = create_new_neural_net()
+
+Agent
+-----
+
+An agent is the entity that performs actions within the environment based on
+its policy.  An agent provides the following methods:
+
+* ``learn() -> None``: This is called to improve the agent's policy via
+  practice within the environment.
+
+
+* ``advance() -> None``: This is called to cause the agent to act within its
+  environment based on its current policy.
+
+The base agent class is defined as follows::
+
+    class Agent:
+        def __init__(self, policy, trainer, environment):
+            self.policy = policy
+            self.trainer = trainer
+            self.environment = environment
+
+        def learn():
+            pass
+
+        def advance():
+            raise NotImplementedError
+
+An example agent class might look like the following::
+
+    import agentos
+
+    class MyAgent(agentos.Agent):
+        def learn(self):
+            self.policy.improve()
+
+        def advance(self):
+            next_action = self.policy.decide(self.obs)
+            self.obs, done, reward, info  = self.environment.step(next_action)
+
+
+Note that ``learn()`` will be a no-op for some agents as the their learning
+might take place while the agent is advancing through its environment.  To
+this end, we propose two common subclasses of the agent:
+
+* ``OnlineAgent``: This agent learns while it advances through its
+  environment.  Thus ``learn()`` will often be a no-op as the policy will be
+  trained each time ``advance()`` gets called.
+
+* ``BatchAgent``: This agent learns in an "offline" manner.  It will either
+  record its various trajectories through the environment or practice in an
+  isolated instantiation of its environment.  This agent's policy will only be
+  trained when ``train()`` is called.
+
+
+Agent Definition File
+---------------------
+
+Every agent will define an ``agent.ini`` file that describes the specific
+components of the agent.  A standard agent directory structure might look
+something like the following::
+
+    my_agent/
+      - main.py
+      - environment.py
+      - policy.py
+      - policy/
+        - serialized_nn.out
+      - agent.ini
+
+Combining our example code from above, our agent's ``agent.ini`` file will
+look like the following::
+
+      [Agent]
+      file_path = agent.py
+      class_name = MyAgent
+      python_path = ./
+
+      [Policy]
+      file_path = policy.py
+      class_name = DeepQNetwork
+      python_path = ./
+      architecture = [10,100,100]
+      buffer_size = 10000
+      batch_size = 100
+      storage = ./policy/
+
+      [Environment]
+      file_path = environment.py
+      class_name = Corridor
+      python_path = ./
+
+
+
+Note that the ``agent.ini`` contains both the location of the primary
+components of the agent as well as various configuration variables and
+hyperparameters.  This file will be managed by the AgentOS Component Registry
+(ACR) to allow for easy composition and reuse of AgentOS components.  It is
+also human readable and editable, if the developer wants to directly modify
+it.
+
+The policy and environment will be accessible within the agent class as
+``self.policy`` and ``self.environment`` respectively.
+
+
+Demo
+====
+
+AgentOS will provide both command line and programmatic access to agents.
+
+A common use case will be using the command-line to train and run an agent as
+follows::
+
+
+    agentos train agent.ini 1000   # Train the agent's policy over 1000 rollouts
+    agentos run agent.ini          # Run our agent to measure performance
+    agentos train agent.ini 1000   # Train our agent on another 1000 rollouts
+    agentos run agent.ini          # Measure performance again
+    agentos reset agent.ini        # Resets the agent's policy; forget all learning
+
+
+The AgentOS CLI provides several ways to run an agent.  You can run using the
+components specified in the ``agent.ini`` in the current directory as
+follows::
+
+    agentos run
+
+Alternatively, you can specify the ``agent.ini`` file to use as follows::
+
+    agentos run -f ../../agent.ini
+
+Finally, you can specify all the components of an agent individually as
+follows::
+
+    agentos run -e myenv.Env -p mypolicy.Policy -a main.MyAgent
+
+
+Additionally, AgentOS provides methods for running agents programmatically
+either using an ``agent.ini`` file::
+
+    agentos.run_agent_file('path/to/file/agent.ini')
+
+Or by specifying each component as a keyword argument::
+
+    agentos.run_agent(
+        agent=MyAgent,
+        environment=MyEnv,
+        policy=MyPolicy,
+    )
+
+Long Term Plans
+===============
+
+* Mark core classes and methods as abstract as appropriate.  See `Abstract
+  Base Classes (ABCs) <https://docs.python.org/3/library/abc.html>`_ and `the
+  ABC PEP <https://www.python.org/dev/peps/pep-3119/>`_.
+
+* Separate out a Reward abstraction from the Environment abstraction.
+
+
+
+Revision History
+================
+
+* Discussion Thread:
+
+  * `Design of Core Abstractions <https://github.com/agentos-project/design_docs/discussions/5>`_
+
+* Pull requests:
+
+  * `design_docs #3: AgentOS Core Abstractions <https://github.com/agentos-project/design_docs/pull/3>`_
+
+* Document version history:
+
+  * `v1 <https://github.com/agentos-project/design_docs/blob/f94af06f8fc66f867ca07bf7273d39d185489251/abstractions.rst>`_
+
+  * `v2 <https://github.com/agentos-project/design_docs/blob/8ea7544c9edc47c1dedd992ba95e9dafeed33b36/abstractions.rst>`_
+
+    * Added code for Agent base class
+
+    * Fixed ``policy()`` function signature to return ``None``
+
+    * Minor rework of description of core abstractions
+
+  * `v3 <https://github.com/agentos-project/design_docs/blob/640f71509c7551b335e6312822392069b6e8c8e9/abstractions.rst>`_
+
+    * Drop Trainer abstraction in favor of `Policy.improve()`
+
+    * Rename `agent.train` to `agent.learn`
+
+    * Default implementation of `Agent.learn` is no-op
+
+    * Default implementation of `Agent.advance` is NotImplementedError
+
+    * Added long-term plans section
+
+  * `v4 <https://github.com/agentos-project/design_docs/blob/271b7450c0d1c50540f170857d9a6357acbd8fd7/abstractions.rst>`_
+
+    * Added user stories
+
+    * Updated ``agent.ini`` example

--- a/documentation/design_docs/registry.rst
+++ b/documentation/design_docs/registry.rst
@@ -1,0 +1,462 @@
+===============================================
+Registry for Environments, Policies, and Agents
+===============================================
+
+Current Version: v7
+
+See `Revision History`_ for additional discussion.
+
+Abstract
+========
+
+An AgentOS agent is composed of **components**.  A component is a shareable,
+swappable package that adheres to a specific API which an agent can incorporate
+into itself.  Currently, components correspond to the core AgentOS abstractions
+(i.e. Environments and Policies).  See the `Core Abstractions Design Doc
+<https://github.com/agentos-project/design_docs/blob/main/abstractions.rst>`_
+for more info.
+
+This document proposes the **AgentOS component registry (ACR)**.  ACR allows
+for easy composition and reuse of AgentOS components much like ``pip`` does for
+Python and ``APT`` does for Debian Linux.
+
+The ACR is integrated with the AgentOS command-line interface (CLI) and a
+centralized registry that provides information for discovering and installing
+components.  It is also a part of the AgentOS runtime which exposes installed
+components within your Agent code.
+
+
+Rationale
+=========
+
+A primary goal of AgentOS is to provide a clean set of abstractions that will
+accelerate the research and development of agent systems.  These abstractions
+provide a straightforward way to swap in existing components to create new
+agents with different behaviors and learning strategies; as long as each
+component respects its interface, the specifics of its implementation should
+not matter for composition.
+
+The ACR enables this vision by:
+
+* Maintaining a centralized registry of agent components including policies and
+  environments.
+
+* Providing a versioning system for these components
+
+* Providing a command-line interface to install these components
+
+* Providing a module for composing components within agents
+
+
+Demo
+====
+
+This section illustrates the usage of ACR by way of example commands and code.
+
+Interaction with the registry
+-----------------------------
+
+First, ensure AgentOS is installed in your environment::
+
+  pip install agentos
+
+Then create a new agent::
+
+  mkdir demo_agent
+  cd demo_agent
+  agentos init . -n DemoAgent
+
+This generates a minimal agent in your ``demo_agent`` directory.  The minimal
+agent is not particularly interesting though, so let's flesh it out.
+
+Let's take a look at the environments available to our agent in the ACR::
+
+  agentos search environment
+
+The above command returns the listings for all components of type
+``environment``.  Now, let's install the ``2048`` environment that models
+the in-browser game `2048 <https://en.wikipedia.org/wiki/2048_(video_game)>`_::
+
+  agentos install environment 2048
+
+The above command not only installs the 2048 environment into your agent
+directory, but it also updates our agent directory's ``agent.ini`` file to
+record the specifics of the components we've installed. Details about the
+``agent.ini`` file can be found `here
+<https://github.com/agentos-project/design_docs/blob/main/abstractions.rst#agent-definition-file>`_.
+
+Our agent will now run against the 2048 game environment.  Now, let's install a
+policy that our agent can use to determine which action to take when given a
+set of observations::
+
+    agentos install policy q_table
+
+We'll use a Q table to track the quality of the actions available to our agent
+in a given state. Policies generally come with an `improve()` method which gets
+called when the agent wants to update its policy based upon experience.
+Policies are also often backed by state (in this case, a data structure
+representing the Q table).
+
+We can now tell our agent to learn so that it becomes better at playing 2048 as
+follows::
+
+  agentos learn -f agent.ini 1000
+
+And we can run our agent as follows::
+
+  agentos run -f agent.ini
+
+As you let your agent run, you'll get periodic updates on its performance
+improvement as it gains more experience playing 2048 and learns via the Q-table
+algorithm.
+
+Some agents will only learn when called via ``agentos learn`` and will have
+their policy frozen during ``agentos run``.  Other agents will learn whenever
+they are run via either method.  This is design decision is up to the agent
+developer and the algorithm they are implementing.
+
+Now suppose we become convinced that a `Deep Q-Learning network
+<https://en.wikipedia.org/wiki/Q-learning>`_ would be more amenable to learning
+2048.  Switching our policy is as easy as running::
+
+  agentos install policy dqn
+
+Because you are installing a second policy, ACR will ask you which you'd like
+to make default.  All installed components are always programmatically
+accessible as members in the agent (e.g. ``self.environments.2048``), but ACR
+initializes the members ``Agent.environment`` and ``Agent.policy`` with the
+default policy and environment respectively.
+
+Go ahead and set ``dqn`` as the default policy.  Again, ``agent.ini`` will be
+updated to reflect that we are now using a DQN-based learning algorithm instead
+of a Q-table based learning algorithm.
+
+Now when you tell your agent to learn again (``agentos learn``) your agent will
+be using Q-learning with a deep Q network to learn 2048.
+
+
+Using components within code
+---------------------------
+
+Let's dig into our minimal agent to see how we access our components
+programmatically::
+
+    from agentos import Agent
+
+    class DemoAgent(Agent):
+        def learn(self):
+            self.policy.improve()
+
+        def advance(self):
+            next_action = self.policy.decide(self.obs)
+            self.obs, done, reward, info  = self.environment.step(next_action)
+
+ACR automatically loads default components into class members of the agent such
+as ``self.policy`` and ``self.environment``.  If you have more than one
+component installed for a particular role (e.g. two complementary environments)
+then you can access each component within the agent via their name::
+
+  self.environments.2048.step()
+  ...
+  self.environments.cartpole.step()
+
+
+MVP
+===
+
+* ACR will be able to access a centralized registry of policies and
+  environments
+
+  * V0 target: the list will be a yaml file stored in the AgentOS repository
+
+* Each registry entry will be structured as follows::
+
+    component_name:
+      type: [policy | environment]
+      agent_os_versions:
+        - [compatible with this AgentOS version]
+        - [compatible with this AgentOS version]
+      description: [component description]
+      releases:
+        - name: [version_1_name]
+          hash: [version_1_hash]
+          github_url: [url of version 1 repo]
+          file_path: [path to py file containing class to import]
+          class_name: [fully qualified class name of version 1]
+          requirements_path: [path to version 1 requirements file]
+
+        - name: [version_2_name]
+          hash: [version_2_hash]
+          github_url: [url of version 2 repo]
+          file_path: [path to py file containing class to import]
+          class_name: [fully qualified class name of version 1]
+          requirements_path: [path to version 2 requirements file]
+
+  for example::
+
+    2048:
+      type: environment
+      agent_os_versions:
+        - 1.0.0
+        - 1.1.0
+      description: "An environment that simulates the 2048 game"
+      releases:
+        - name: 1.0.0
+          hash: aeb938f
+          github_url: https://github.com/example-proj/example-repo
+          file_path: environment.py
+          class_name: 2048
+          requirements_path: requirements.txt
+
+        - name: 1.1.0
+          hash: 3939aa1
+          github_url: https://github.com/example-proj/example-repo
+          file_path: environment.py
+          class_name: 2048
+          requirements_path: requirements.txt
+
+* Each component will be a (v0: Python) project stored in a Github repo.
+
+* ACR will have an ``search`` method that will list all components in the
+  registry matching the search query.
+
+* ACR will have an ``install`` method that will:
+
+  * Find the components location based on its registry entry
+
+  * Ask if you'd like to install the component as the default in cases where
+    there are multiple installed components of the same type.
+
+  * Clone the component's Github repo
+
+  * Update the agent directory's ``agent.ini`` to include the component in
+    its default configuration
+
+  * Register the component locally so that it is accessible via the ``acr``
+    module
+
+  * Add a line to the agent directory's requirements file that links to the
+    component's requirements file (e.g. a line of the form
+    `-r component/repo/path/requirements.txt`.).
+
+* ACR will have an ``uninstall`` method that will remove the component from the
+  agent directory (including any links to the component's requirements).
+
+* Components can be programmatically accessed from the ``acr`` module
+
+* Developers have an easy way to register their local custom components with
+  ``acr`` so it can be accessed via the ``acr`` module in other parts of their
+  agent.
+
+* The minimal agent (``agentos init``) will be ACR aware and incorporate
+  basic components with minimal required edits
+
+
+Long Term Plans
+===============
+
+* A simple way for component authors to submit components to the registry via
+  command-line and web interface.
+    * For example, this might be two commands:
+        * ``agentos package ...`` - packages up the component
+        * ``agentos register ...`` - pushes the component listing to the
+          centralized registry
+
+* A way for agent developers to detect and resolve requirement conflicts
+  between already-installed and soon-to-be-installed components.
+
+* Agents are not components, but it still seems like it'd be useful to share
+  agents.  Long term, we will extend the registry system to encompass agents as
+  well.
+
+* Break ACR into two components:
+
+    * Package management functionality:
+        * ``agentos install``
+        * ``agentos search``
+        * ``agentos uninstall``
+        * ``agentos status`` - new command to show what's available in your
+          agent
+
+    * Git-like mapping tools
+        * commands to map particular versions of installed components to
+          particular members available in the Agent class.
+
+* Expose the state backing a particular policy as a separate, shareable
+  component.
+
+
+FAQ
+===
+
+**Q:** My [complex component] has a number of hyperparameters that need to be
+tuned based on the particulars of the environment and the agent.  How do I do
+this?
+
+**A:** Each component exposes a configuration in its ``agent.ini`` entry. This
+allows for both manual tweaking of hyperparameters as well as programmatic
+exploration and tuning (with e.g. `sk-learn grid search
+<https://scikit-learn.org/stable/modules/grid_search.html>`_).  See also the
+example ``agent.ini`` file `here
+<https://github.com/agentos-project/design_docs/blob/main/abstractions.rst#agent-definition-file>`_.
+
+
+**Q:** How can I reuse a policy from a previous run?
+
+**A:** Policies are top-level components and are often backed by some sort of
+state.  ``agentos run`` has tooling that allows you to dynamically specify when
+and how to reuse existing models.
+
+**Q:** Can only 1 component of each type be installed in an agent at a time?
+
+**A:** ACR allows multiple components of a single type. The ``agent.ini``
+configuration file defines the default for each component type and that default
+is accessible programmatically via shortcuts within the agent like
+``self.policy`` and ``self.environment``.
+
+In an agent where you have, for example, two policies installed (e.g.
+``random`` and ``dqn``) the default (as determined by ``agent.ini``) will be
+accessible within the agent as ``self.policy``, but both will always be
+accessible at ``acr.policies.random`` and ``acr.policies.dqn`` respectively.
+
+**Q:** How does AgentOS locate the main code of the component within the Github
+repo? Must all components have a well known entry point (e.g., a file called
+main.py)?
+
+**A:** The ACR registry entry for each version of a component contains
+sufficient information to discover the entry point of the component and its
+requirements.
+
+We may eventually:
+
+* Require a component's repo to store additional metadata (perhaps in a
+  top level ``agent.ini`` file) that ACR tooling can ingest to alleviate
+  concerns about mismatches between registry info and repo info (e.g. a
+  component's version is different in the registry and in the repo).
+
+* Require all components to be proper Python packages so we can reuse Python's
+  ``setup.py`` tooling.
+
+
+**Q:** Will we update the code generated by ``agentos init`` so that it will
+use the ACR module?
+
+**A:** Yes, the default agent uses some very basic components that are included
+out-of-the-box in AgentOS (e.g. random action policy, a basic corridor
+environment).  The ``agentos init`` command creates the ``agent.ini`` file that
+specifies these defaults.
+
+**Q:** Do we want to design the API so that using a component from the registry
+looks exactly (or nearly) the same as using a hand-built component.  Basically,
+should we recommend using the same sort of composition for both composing an
+agent from an environment, policy, and algorithm built from scratch and
+composing an agent entirely from pre-built components in the registry?
+
+**A:**  Yes, I think nudging users toward consistency would be good.  I think
+that means component specifications and APIs that are well documented and
+tooling that makes it valuable to build to those specs.
+
+Ultimately, if someone wants to give their custom environment a nonstandard
+``proceed_one_step_in_time()`` function instead of a ``step()`` function, we
+shouldn't try to stop them.  But we should instead strive to make it high-value
+to standardize because you can use a bunch of great tools out-of-the-box on
+your component programmed to the spec.
+
+Diving down closer to the code, I think we need to provide an easy way to, for
+example, register your custom environment so that you can access it via
+``self.environment`` within your agent, and encourage exposing and interacting
+with your custom components in this way.
+
+
+**Q:** How does this relate to OpenAI's ``gym.envs.registry``, if at all?
+
+**A:** The idea of having an ``acr`` module that you can import in your Python
+code is inspired by the ``gym.envs.registry``.  The ``acr`` module dynamically
+loads in the available components much like gym's registry.
+
+One rationale I found for OpenAI's environment registry is
+[here](https://github.com/openai/gym/blob/master/gym/envs/registration.py#L76)
+and essentially amounts to versioning an environment.  We solve this problem by
+requiring a git hash for every "released" version of a component.
+
+**Q:** How does this relate to how AgentOS uses MLflow for Agent Directories.
+Should we merge the two concepts? Or at least unify them? Maybe get rid of the
+dependency on MLflow?
+
+**A:**  I think MLflow will be useful and should remain a dependency; one will
+still have to perform various runs with an agent (e.g. to tune hyperparameters)
+and MLflow's tracking and visualization should be useful for that.
+
+In fact, one could think of the components themselves as hyperparameters to the
+agent, and some sort of deeper integration with MLflow would probably be
+valuable ("On the first run I used a Deep Q Network component with 128 nodes to
+represent my Q function, while on my second run I used a table component with
+512K entries").
+
+TODO and open questions
+=======================
+
+* How to handle component dependencies (Both package and component-level)?
+
+  * `StackOverflow on conditional requirements <https://stackoverflow.com/a/29222444>`_
+  * How to fail gracefully if there are incompatible requirements
+  * Perhaps use separate processes to isolate run environments
+  * Can we just use the Python package system and pip directly?
+
+* What are the key components that we want to expose in our registry?
+  Candidates: Agents, Policies, Environments, Policy-state
+
+Revision History
+================
+
+* Discussion Thread:
+
+  * `AgentOS Component Registry <https://github.com/agentos-project/design_docs/discussions/7>`_
+
+* Important pull requests:
+
+  * `design_docs #1: AgentOS registry <https://github.com/agentos-project/design_docs/pull/1>`_
+  * `design_docs #2: Avoid merging requirements on component install <https://github.com/agentos-project/design_docs/pull/2>`_
+  * `design_docs #10: Design doc updates: Abstractions and Registry <https://github.com/agentos-project/design_docs/pull/10>`_
+
+* Document version history:
+
+  * `v1 <https://github.com/agentos-project/design_docs/blob/36791f4ef1cf408c19cf13042bb7cc6b72cb6030/registry.rst>`_
+  * `v2 <https://github.com/agentos-project/design_docs/blob/020a70a5e538b58e5e0ff269f44a7f206a7b132e/registry.rst>`_
+  * `v3 <https://github.com/agentos-project/design_docs/blob/e32ff7a96eab3486a3c8bb65c1ca1df280e20434/registry.rst>`_
+  * `v4 <https://github.com/agentos-project/design_docs/blob/507bfb96a1b40bef8338603a3e661681d0d622c7/registry.rst>`_
+  * `v5 <https://github.com/agentos-project/design_docs/blob/886f5a0eb960c398cc57d7cd5ec97956c528cca4/registry.rst>`_
+  * `v6 <https://github.com/agentos-project/design_docs/blob/2ec8b7f231330119d153a24725537a7c4e71084d/registry.rst>`_
+
+    * Rename AgentOS Component System (ACS) to AgentOS Component Registry (ACR)
+
+    * Rename ``components.ini`` to ``agent.ini``
+
+    * Update demo to reflect core abstractions and new CLI
+
+    * Update FAQ to reflect recent discussions on core abstractions
+
+  * `v7 <https://github.com/agentos-project/design_docs/blob/271b7450c0d1c50540f170857d9a6357acbd8fd7/registry.rst>`_
+
+    * Address discussion feedback `here
+      <https://github.com/agentos-project/design_docs/discussions/7#discussioncomment-361544>`_.
+
+    * Address meeting feedback `here
+      <https://github.com/agentos-project/design_docs/discussions/7#discussioncomment-364414>`_.
+
+    * Rewrote abstract to better define terms
+
+    * Removed Trainer abstraction
+
+    * Reworked demo (no Trainer, updates to CLI interface)
+
+    * Update registry entry spec
+
+    * Added more long term plans
+
+Further Reading
+===============
+
+* `AgentOS Issue 68: Registery for Envs, Policies, and Agents <https://github.com/agentos-project/agentos/issues/68>`_
+* `PEP 301 -- Package Index and Metadata for Distutils <https://www.python.org/dev/peps/pep-0301/>`_
+* `PEP 243 -- Module Repository Upload Mechanism <https://www.python.org/dev/peps/pep-0243/>`_

--- a/documentation/includes/developing.rst
+++ b/documentation/includes/developing.rst
@@ -38,7 +38,7 @@ process is to:
 * Allow developers to think through a design, and
 * Allow stakeholders to give feedback
 
-...**before** development begins.
+...before development begins.
 
 If you'd like to propose a feature, please follow the procedure found in the
 `design_docs README <documentation/design_docs/README.rst>`_.  You can also

--- a/documentation/includes/developing.rst
+++ b/documentation/includes/developing.rst
@@ -31,19 +31,18 @@ To contribute to AgentOS, the general workflow is as follows:
 Proposing Features
 ==================
 
-For new features and other big chunks of work, AgentOS maintains a `repo of
-design documents <https://github.com/agentos-project/design_docs>`_.  The goal
-of these design documents is to:
+For new features and other big chunks of work, AgentOS uses a design process
+centered around design proposals, discussions, and design docs. The goal of the
+process is to:
 
 * Allow developers to think through a design, and
 * Allow stakeholders to give feedback
 
-before development begins.
+...**before** development begins.
 
 If you'd like to propose a feature, please follow the procedure found in the
-`design_docs README
-<https://github.com/agentos-project/design_docs/blob/main/README.rst>`_.  You
-can also browse other design docs in the repo to get a feel for the general
+`design_docs README <documentation/design_docs/README.rst>`_.  You can also
+browse existing design docs in the folder to get a feel for the general
 content and style.
 
 


### PR DESCRIPTION
Per https://github.com/agentos-project/design_docs/discussions/8, this copies over the existing design_docs and updated readme. It also updates references to the design process in the main agentos documentation (i.e., in the README and the website).

After we merge this PR, next steps are:

1. move over the open discussion threads from the `design_docs` repo
2. archive `design_docs` repo

