### PR TITLE
`agentos reset` and other minor functionality updates

### DIFF
--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -85,6 +85,13 @@ _option_test_num_episodes = click.option(
     help="Number of episodes to run for performance eval.",
 )
 
+_option_max_transitions = click.option(
+    "--max-transitions",
+    "-m",
+    type=click.INT,
+    default=None,
+    help="The maximium number of transitions before truncating an episode",
+)
 _option_verbose = click.option(
     "--verbose",
     "-v",
@@ -138,6 +145,7 @@ def init(dir_names, agent_name, agentos_dir):
 @_option_test_num_episodes
 @_option_agent_file
 @_option_agentos_dir
+@_option_max_transitions
 @_option_verbose
 def learn(
     num_episodes,
@@ -145,6 +153,7 @@ def learn(
     test_num_episodes,
     agent_file,
     agentos_dir,
+    max_transitions,
     verbose,
 ):
     _check_path_exists(agentos_dir)
@@ -154,6 +163,7 @@ def learn(
         test_num_episodes=test_num_episodes,
         agent_file=agent_file,
         agentos_dir=agentos_dir,
+        max_transitions=max_transitions,
         verbose=verbose,
     )
 
@@ -163,14 +173,16 @@ def learn(
 @_option_num_episodes
 @_option_agent_file
 @_option_agentos_dir
+@_option_max_transitions
 @_option_verbose
-def run(num_episodes, agent_file, agentos_dir, verbose):
+def run(num_episodes, agent_file, agentos_dir, max_transitions, verbose):
     """Run an agent by calling advance() on it until it returns True"""
     _check_path_exists(agentos_dir)
     agentos.run_agent(
         num_episodes=num_episodes,
         agent_file=agent_file,
         agentos_dir=agentos_dir,
+        max_transitions=max_transitions,
         should_learn=False,
         verbose=verbose,
         backup_dst=None,

--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -168,8 +168,8 @@ def learn(
         test_num_episodes=test_num_episodes,
         agent_file=agent_file,
         agentos_dir=agentos_dir,
-        max_transitions=max_transitions,
         verbose=verbose,
+        max_transitions=max_transitions,
     )
 
 
@@ -186,9 +186,9 @@ def run(num_episodes, agent_file, agentos_dir, max_transitions, verbose):
         num_episodes=num_episodes,
         agent_file=agent_file,
         agentos_dir=agentos_dir,
-        max_transitions=max_transitions,
         should_learn=False,
         verbose=verbose,
+        max_transitions=max_transitions,
         backup_dst=None,
         print_stats=True,
     )

--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -5,7 +5,6 @@ The CLI allows creation of a simple template agent.
 import agentos
 import click
 from agentos import runtime
-from pathlib import Path
 
 
 @click.group()
@@ -99,6 +98,14 @@ _option_verbose = click.option(
     help="Agent prints verbose logs.",
 )
 
+_option_backup_id = click.option(
+    "--from-backup-id",
+    "-b",
+    metavar="BACKUP_ID",
+    type=str,
+    help="Resets agent to given backup ID. Expects a UUID.",
+)
+
 
 @agentos_cmd.command()
 @_arg_component_name
@@ -107,7 +114,6 @@ _option_verbose = click.option(
 @_option_assume_yes
 def install(component_name, agent_file, agentos_dir, assume_yes):
     """Installs PACKAGE_NAME"""
-    _check_path_exists(agentos_dir)
     runtime.install_component(
         component_name=component_name,
         agentos_dir=agentos_dir,
@@ -138,7 +144,7 @@ def init(dir_names, agent_name, agentos_dir):
     )
 
 
-# TODO - reimplement hz and max_iters
+# TODO - reimplement hz
 @agentos_cmd.command()
 @_option_num_episodes
 @_option_test_every
@@ -156,7 +162,6 @@ def learn(
     max_transitions,
     verbose,
 ):
-    _check_path_exists(agentos_dir)
     agentos.learn(
         num_episodes=num_episodes,
         test_every=test_every,
@@ -168,7 +173,7 @@ def learn(
     )
 
 
-# TODO - reimplement hz and max_iters
+# TODO - reimplement hz
 @agentos_cmd.command()
 @_option_num_episodes
 @_option_agent_file
@@ -177,7 +182,6 @@ def learn(
 @_option_verbose
 def run(num_episodes, agent_file, agentos_dir, max_transitions, verbose):
     """Run an agent by calling advance() on it until it returns True"""
-    _check_path_exists(agentos_dir)
     agentos.run_agent(
         num_episodes=num_episodes,
         agent_file=agent_file,
@@ -190,9 +194,13 @@ def run(num_episodes, agent_file, agentos_dir, max_transitions, verbose):
     )
 
 
-def _check_path_exists(path):
-    if not Path(path).absolute().exists():
-        raise click.BadParameter(f"{path} does not exist!")
+@agentos_cmd.command()
+@_option_agentos_dir
+@_option_backup_id
+def reset(agentos_dir, from_backup_id):
+    runtime.reset_agent_directory(
+        agentos_dir=agentos_dir, from_backup_id=from_backup_id
+    )
 
 
 if __name__ == "__main__":

--- a/agentos/core.py
+++ b/agentos/core.py
@@ -171,6 +171,9 @@ class Environment(MemberInitializer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        if "shared_data" in kwargs:
+            shared_data = kwargs["shared_data"]
+            shared_data["environment_spec"] = self.get_spec()
         self.action_space = None
         self.observation_space = None
         self.reward_range = None

--- a/agentos/core.py
+++ b/agentos/core.py
@@ -66,7 +66,7 @@ class Agent(MemberInitializer):
             self._should_reset = True
         return prev_obs, action, self.curr_obs, reward, done, info
 
-    def rollout(self, should_learn, max_transitions):
+    def rollout(self, should_learn, max_transitions=None):
         """Generates one episode of transitions and allows the Agent to
         learn from its experience.
 

--- a/agentos/core.py
+++ b/agentos/core.py
@@ -66,29 +66,45 @@ class Agent(MemberInitializer):
             self._should_reset = True
         return prev_obs, action, self.curr_obs, reward, done, info
 
-    def rollout(self, should_learn):
+    def rollout(self, should_learn, max_transitions):
         """Generates one episode of transitions and allows the Agent to
         learn from its experience.
 
-        If the parameter <should_learn> is True, then Trainer.improve() will
-        be called every time the Agent advances one step through the
-        environment and the core training metrics (transition_count and
-        episode_count)  will be updated after the rollout.
+        :param should_learn: if True, then Trainer.improve() will be called
+                             every time the Agent advances one step through the
+                             environment and the core training metrics
+                             (transition_count and episode_count) will be
+                             updated after the rollout.
+        :param max_transitions: If not None, the episode and rollout will be
+                                truncated after the specified number of
+                                transitions.
+
+        :returns: Number of transitions experienced in this episode.
         """
         done = False
         transition_count = 0
         while not done:
+            if max_transitions and transition_count > max_transitions:
+                self._episode_truncated()
+                break
             _, _, _, _, done, _ = self.advance()
             transition_count += 1
             if should_learn:
                 self.trainer.improve(self.dataset, self.policy)
         if should_learn:
+            self.trainer.improve(self.dataset, self.policy)
             prev_transition_count = self.get_transition_count()
             new_transition_count = prev_transition_count + transition_count
             self.save_transition_count(new_transition_count)
             prev_episode_count = self.get_episode_count()
             self.save_episode_count(prev_episode_count + 1)
         return transition_count
+
+    def _episode_truncated(self):
+        # TODO - record truncations to improve training?
+        # See truncation() in
+        # https://github.com/deepmind/dm_env/blob/master/dm_env/_environment.py
+        pass
 
     def get_transition_count(self):
         """Gets the number of transitions the Agent has been trained on."""

--- a/agentos/runtime.py
+++ b/agentos/runtime.py
@@ -22,9 +22,9 @@ def run_agent(
     num_episodes,
     agent_file,
     agentos_dir,
-    max_transitions,
     should_learn,
     verbose,
+    max_transitions=None,
     backup_dst=None,
     print_stats=False,
 ):
@@ -33,10 +33,10 @@ def run_agent(
     :param num_episodes: number of episodes to run the agent through
     :param agent_file: path to the agent config file
     :param agentos_dir: Directory path containing AgentOS components and data
-    :param max_transitions: If not None, max transitions performed before
-                            truncating an episode.
     :param should_learn: boolean, if True we will call policy.improve
     :param verbose: boolean, if True will print debugging data to stdout
+    :param max_transitions: If not None, max transitions performed before
+                            truncating an episode.
     :param backup_dst: if specified, will print backup path to stdout
     :param print_stats: if True, will print run stats to stdout
 
@@ -101,8 +101,8 @@ def learn(
     test_num_episodes,
     agent_file,
     agentos_dir,
-    max_transitions,
     verbose,
+    max_transitions=None,
 ):
     """Trains an agent by calling its learn() method in a loop."""
     _check_path_exists(agentos_dir)
@@ -116,9 +116,9 @@ def learn(
                 num_episodes=test_num_episodes,
                 agent_file=agent_file,
                 agentos_dir=agentos_dir,
-                max_transitions=max_transitions,
                 should_learn=False,
                 verbose=verbose,
+                max_transitions=max_transitions,
                 backup_dst=backup_dst,
                 print_stats=True,
             )
@@ -126,9 +126,9 @@ def learn(
             num_episodes=run_size,
             agent_file=agent_file,
             agentos_dir=agentos_dir,
-            max_transitions=max_transitions,
             should_learn=True,
             verbose=verbose,
+            max_transitions=max_transitions,
             backup_dst=None,
             print_stats=True,
         )

--- a/agentos/runtime.py
+++ b/agentos/runtime.py
@@ -22,6 +22,7 @@ def run_agent(
     num_episodes,
     agent_file,
     agentos_dir,
+    max_transitions,
     should_learn,
     verbose,
     backup_dst=None,
@@ -32,6 +33,8 @@ def run_agent(
     :param num_episodes: number of episodes to run the agent through
     :param agent_file: path to the agent config file
     :param agentos_dir: Directory path containing AgentOS components and data
+    :param max_transitions: If not None, max transitions performed before
+                            truncating an episode.
     :param should_learn: boolean, if True we will call policy.improve
     :param verbose: boolean, if True will print debugging data to stdout
     :param backup_dst: if specified, will print backup path to stdout
@@ -45,39 +48,13 @@ def run_agent(
         _print_agent_parameters(agent)
 
     for i in range(num_episodes):
-        steps = agent.rollout(should_learn)
+        steps = agent.rollout(
+            should_learn=should_learn, max_transitions=max_transitions
+        )
         all_steps.append(steps)
 
     if print_stats:
         _print_run_results(agent, all_steps, backup_dst)
-
-
-def _print_agent_parameters(agent):
-    print()
-    print("Agent parameters:")
-    pprint.pprint(agentos.parameters.__dict__)
-    print()
-
-
-def _print_run_results(agent, all_steps, backup_dst):
-    if not all_steps:
-        return
-    mean = statistics.mean(all_steps)
-    median = statistics.median(all_steps)
-    print()
-    print(f"Benchmark results after {len(all_steps)} rollouts:")
-    print(
-        "\tBenchmarked agent was trained on "
-        f"{agent.get_transition_count()} "
-        f"transitions over {agent.get_episode_count()} episodes"
-    )
-    print(f"\tMax steps over {len(all_steps)} trials: {max(all_steps)}")
-    print(f"\tMean steps over {len(all_steps)} trials: {mean}")
-    print(f"\tMedian steps over {len(all_steps)} trials: {median}")
-    print(f"\tMin steps over {len(all_steps)} trials: {min(all_steps)}")
-    if backup_dst:
-        print(f"Agent backed up in {backup_dst}")
-    print()
 
 
 def install_component(component_name, agentos_dir, agent_file, assume_yes):
@@ -122,6 +99,7 @@ def learn(
     test_num_episodes,
     agent_file,
     agentos_dir,
+    max_transitions,
     verbose,
 ):
     """Trains an agent by calling its learn() method in a loop."""
@@ -135,6 +113,7 @@ def learn(
                 num_episodes=test_num_episodes,
                 agent_file=agent_file,
                 agentos_dir=agentos_dir,
+                max_transitions=max_transitions,
                 should_learn=False,
                 verbose=verbose,
                 backup_dst=backup_dst,
@@ -144,6 +123,7 @@ def learn(
             num_episodes=run_size,
             agent_file=agent_file,
             agentos_dir=agentos_dir,
+            max_transitions=max_transitions,
             should_learn=True,
             verbose=verbose,
             backup_dst=None,
@@ -258,6 +238,34 @@ parameters = ParameterObject()
 ################################
 # Private helper functions below
 ################################
+
+
+def _print_agent_parameters(agent):
+    print()
+    print("Agent parameters:")
+    pprint.pprint(agentos.parameters.__dict__)
+    print()
+
+
+def _print_run_results(agent, all_steps, backup_dst):
+    if not all_steps:
+        return
+    mean = statistics.mean(all_steps)
+    median = statistics.median(all_steps)
+    print()
+    print(f"Benchmark results after {len(all_steps)} rollouts:")
+    print(
+        "\tBenchmarked agent was trained on "
+        f"{agent.get_transition_count()} "
+        f"transitions over {agent.get_episode_count()} episodes"
+    )
+    print(f"\tMax steps over {len(all_steps)} trials: {max(all_steps)}")
+    print(f"\tMean steps over {len(all_steps)} trials: {mean}")
+    print(f"\tMedian steps over {len(all_steps)} trials: {median}")
+    print(f"\tMin steps over {len(all_steps)} trials: {min(all_steps)}")
+    if backup_dst:
+        print(f"Agent backed up in {backup_dst}")
+    print()
 
 
 def _back_up_agent(agentos_dir):

--- a/agentos/runtime.py
+++ b/agentos/runtime.py
@@ -8,6 +8,7 @@ import uuid
 import sys
 import yaml
 import click
+import pprint
 from datetime import datetime
 import importlib.util
 from pathlib import Path
@@ -40,27 +41,43 @@ def run_agent(
     """
     all_steps = []
     agent = load_agent_from_path(agent_file, agentos_dir, verbose)
+    if print_stats:
+        _print_agent_parameters(agent)
+
     for i in range(num_episodes):
         steps = agent.rollout(should_learn)
         all_steps.append(steps)
 
-    if print_stats and all_steps:
-        mean = statistics.mean(all_steps)
-        median = statistics.median(all_steps)
-        print()
-        print(f"Benchmark results after {len(all_steps)} rollouts:")
-        print(
-            "\tBenchmarked agent was trained on "
-            f"{agent.get_transition_count()} "
-            f"transitions over {agent.get_episode_count()} episodes"
-        )
-        print(f"\tMax steps over {num_episodes} trials: {max(all_steps)}")
-        print(f"\tMean steps over {num_episodes} trials: {mean}")
-        print(f"\tMedian steps over {num_episodes} trials: {median}")
-        print(f"\tMin steps over {num_episodes} trials: {min(all_steps)}")
-        if backup_dst:
-            print(f"Agent backed up in {backup_dst}")
-        print()
+    if print_stats:
+        _print_run_results(agent, all_steps, backup_dst)
+
+
+def _print_agent_parameters(agent):
+    print()
+    print("Agent parameters:")
+    pprint.pprint(agentos.parameters.__dict__)
+    print()
+
+
+def _print_run_results(agent, all_steps, backup_dst):
+    if not all_steps:
+        return
+    mean = statistics.mean(all_steps)
+    median = statistics.median(all_steps)
+    print()
+    print(f"Benchmark results after {len(all_steps)} rollouts:")
+    print(
+        "\tBenchmarked agent was trained on "
+        f"{agent.get_transition_count()} "
+        f"transitions over {agent.get_episode_count()} episodes"
+    )
+    print(f"\tMax steps over {len(all_steps)} trials: {max(all_steps)}")
+    print(f"\tMean steps over {len(all_steps)} trials: {mean}")
+    print(f"\tMedian steps over {len(all_steps)} trials: {median}")
+    print(f"\tMin steps over {len(all_steps)} trials: {min(all_steps)}")
+    if backup_dst:
+        print(f"Agent backed up in {backup_dst}")
+    print()
 
 
 def install_component(component_name, agentos_dir, agent_file, assume_yes):

--- a/agentos/templates/environment.py
+++ b/agentos/templates/environment.py
@@ -23,7 +23,7 @@ class Corridor(agentos.Environment):
             self.position = np.array(
                 [np.float32(min(self.position[0] + 1, self.length))]
             )
-        return (self.position, -1, self.done, {{}})
+        return (self.position, np.float32(-1), self.done, dict())
 
     def reset(self):
         self.position = np.array([np.float32(0)])
@@ -34,7 +34,9 @@ class Corridor(agentos.Environment):
             shape=(1,), dtype=np.dtype("float32"), name="observations"
         )
         actions = specs.DiscreteArray(num_values=2, name="actions")
-        rewards = specs.Array(shape=(), dtype=np.dtype("int64"), name="reward")
+        rewards = specs.Array(
+            shape=(), dtype=np.dtype("float32"), name="reward"
+        )
         discounts = specs.BoundedArray(
             shape=(),
             dtype=np.dtype("float32"),

--- a/registry.yaml
+++ b/registry.yaml
@@ -41,7 +41,7 @@ acme_r2d2_policy:
   description: "R2D2 policy ported from Acme framework"
   releases:
     - name: 1.0.0
-      hash: 6cb269f848ec0df2603073dd9283ba30bd822105
+      hash: 24d796bed3795a6a31bfcc2e09c1aa4a4fc171ea
       github_url: https://github.com/nickjalbert/acme_r2d2_policy
       file_path: policy.py
       class_name: R2D2Policy

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,9 +21,9 @@ def test_cli(tmpdir):
     for expected_file_name in expected_file_names:
         expected_path = Path(tmpdir) / expected_file_name
         assert expected_path.is_file(), f"{expected_file_name} not found"
-    commands = [["agentos", "learn"], ["agentos", "run"]]
-    for c in commands:
-        subprocess.run(c, cwd=tmpdir, check=True)
+    subprocess.run(["agentos", "run"], cwd=tmpdir, check=True)
+    subprocess.run(["agentos", "learn"], cwd=tmpdir, check=True)
+    subprocess.run(["agentos", "reset"], cwd=tmpdir, check=True)
 
     # TODO(andyk): add functionality for creating a conda env
     #              automatically if an MLProject file does not


### PR DESCRIPTION
A few small features that helped with debugging as I was finishing the Acme R2D2 port:

* `agentos reset` removes any data backing the agent (e.g. NNs backing a policy, training statistics) so you can re-train from scratch.  `agentos reset -b [backup UUID]` restores the agent backing data specified by the UUID.  I imagine the mechanisms for these might change as you get deeper into your work on hierarchical components and MLFlow.
* Added back in the `--max-iters` flag (renamed to `--max-transitions`) for `agentos run` and `agentos learn`.
* Updated the default environment (the corridor environment you get after `agentos init`) so that it will work with the Acme R2D2 agent.  For example:
```
mkdir corridor_agent
cd corridor_agent
agentos install acme_r2d2_policy
agentos install acme_r2d2_trainer
agentos install acme_r2d2_dataset
agentos run -m 200
```
* The agent prints all its hyperparameters to the console when it runs.
