### PR TITLE
Bump requirements to satisfy dependabot

### DIFF
--- a/example_agents/acme_r2d2/requirements.txt
+++ b/example_agents/acme_r2d2/requirements.txt
@@ -12,6 +12,7 @@ cachetools==4.2.2
 certifi==2019.11.28
 cffi==1.14.6
 chardet==3.0.4
+clang==5.0
 click==8.0.1
 cloudpickle==1.3.0
 colorama==0.4.3
@@ -22,10 +23,9 @@ databricks-cli==0.14.3
 decorator==5.0.9
 distlib==0.3.0
 distro==1.4.0
-dm-acme[tensorflow]==0.2.1
+dm-acme==0.2.1
 dm-env==1.5
-dm-reverb==0.3.1
-dm-reverb-nightly==0.3.0.dev20210712
+dm-reverb==0.5.0
 dm-sonnet==2.0.0
 dm-tree==0.1.6
 docker==5.0.0
@@ -43,7 +43,7 @@ google-auth==1.32.1
 google-auth-oauthlib==0.4.4
 google-pasta==0.2.0
 gorilla==0.4.0
-grpcio==1.34.1
+grpcio==1.41.0
 gunicorn==20.1.0
 gym==0.17.1
 h5py==3.1.0
@@ -56,7 +56,7 @@ itsdangerous==2.0.1
 jax==0.2.17
 jaxlib==0.1.68
 Jinja2==3.0.1
-keras-nightly==2.5.0.dev2021032900
+keras==2.6.0
 Keras-Preprocessing==1.1.2
 kiwisolver==1.3.1
 launchpad==1.1.0
@@ -77,7 +77,7 @@ packaging==20.3
 pandas==1.3.0
 pathspec==0.8.1
 pep517==0.8.2
-Pillow==8.3.1
+Pillow==8.3.2
 portpicker==1.4.0
 progress==1.5
 prometheus-client==0.11.0
@@ -108,13 +108,13 @@ scribble==1.0.0
 six==1.15.0
 smmap==4.0.0
 SQLAlchemy==1.3.13
-sqlparse==0.4.1
+sqlparse==0.4.2
 tabulate==0.8.9
-tensorboard==2.5.0
+tensorboard==2.6.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.0
-tensorflow==2.5.0
-tensorflow-estimator==2.5.0
+tensorflow==2.6.0
+tensorflow-estimator==2.6.0
 tensorflow-probability==0.13.0
 termcolor==1.1.0
 toml==0.10.2


### PR DESCRIPTION
Bumping a few requirements that will:

1) Hopefully satisfy dependabot 
    * #149
    * #150 
    * #151
2) Fix a bug where I couldn't just `pip install -r requirements.txt` in `example_agents/acme_r2d2/` on a clean environment and get the agent to run.  Got some weird keras error:

    ````
      ...
      File "/home/nickj/agentos/example_agents/acme_r2d2/delme_env/lib/python3.9/site-packages/keras/engine/input_layer.py", line 21, in <module>
        from keras.engine import base_layer
      File "/home/nickj/agentos/example_agents/acme_r2d2/delme_env/lib/python3.9/site-packages/keras/engine/base_layer.py", line 41, in <module>
        from keras.mixed_precision import loss_scale_optimizer
      File "/home/nickj/agentos/example_agents/acme_r2d2/delme_env/lib/python3.9/site-packages/keras/mixed_precision/loss_scale_optimizer.py", line 1180, in <module>
        mixed_precision._register_wrapper_optimizer_cls(optimizer_v2.OptimizerV2,

      AttributeError: module 'tensorflow.python.training.experimental.mixed_precision' has no attribute '_register_wrapper_optimizer_cls'
    ````