### PR TITLE
Fix two bugs in AgentOS runtime

### DIFF
--- a/agentos/runtime.py
+++ b/agentos/runtime.py
@@ -151,10 +151,14 @@ def load_component_from_file(spec_file, component_name, params):
             try:
                 component_init_params = params[c_name]["init"]
             except KeyError:
+                component_init_params = None
+            if component_init_params is None:
                 component_init_params = {}
             try:
                 global_params = params["__global__"]
             except KeyError:
+                global_params = None
+            if global_params is None:
                 global_params = {}
             init_params = {**global_params, **component_init_params}
             sig = signature(c_instance.init)


### PR DESCRIPTION
Ran into a couple bugs while porting an Acme DQN agent

## Blank sections in agent spec files

The first bug occurs when agent spec files have blank sections like [this](https://github.com/nickjalbert/dummy_agent/blob/c5b79416927f94ad3eb39bcbf374ac0fd7235bf6/parameters.yaml#L11).  To demo:

```
# Clone my dummy agent
git clone git@github.com:nickjalbert/dummy_agent.git
cd dummy_agent
git checkout c5b7941

# Make a virtual env
virtualenv -p /usr/bin/python3 env
source env/bin/activate
pip install -e [path/to/agentos/master]

# Attempt to run the Agent
agentos run agent --entry-point evaluate --param-file parameters.yaml
```

The above results in something like the following on agentos master:

```
  ...
  File "/home/nickj/agentos/agentos/runtime.py", line 55, in run_component
    component = load_component_from_file(
  File "/home/nickj/agentos/agentos/runtime.py", line 164, in load_component_from_file
    init_params = {**global_params, **component_init_params}
TypeError: 'NoneType' object is not a mapping
```

## No `init()` called in components without dependencies

The second bug occurs because we only add visited components to the `__component_stack__` if the component has dependencies.  To see this bug, run the following:

```
# IMPORTANT: Perform previous demo

# Checkout new commit
git checkout 4684576

# Attempt to run the Agent
agentos run agent --entry-point evaluate --param-file parameters.yaml
```

You will see the following output:

```
Adding environment as dependency of network
Adding network as dependency of agent
Adding environment as dependency of agent
Running DummyNetwork.init()
Running DummyAgent.init()
Running DummyAgent.evaluate()
```

Note that we *don't* see `DummyEnvironment.init()` run even though we'd [expect it to be](https://github.com/nickjalbert/dummy_agent/blob/468457666d35daaff2ca3a887c16f24073e823bb/environment.py#L5).  This was a bit tricky to track down.

## Putting them together

If you checkout the branch in the pull request in your acme installation, you can see the agent running with both blank parameter sections and `DummyEnvironment.init()` being called:

```
# Pull this branch for your environment's agentos install

# Back to dummy_agent dir
git checkout c5b7941

agentos run agent --entry-point evaluate --param-file parameters.yaml
```

And you should see:

```
Adding environment as dependency of network
Adding network as dependency of agent
Adding environment as dependency of agent
Running DummyEnvironment.init()
Running DummyNetwork.init()
Running DummyAgent.init()
Running DummyAgent.evaluate()
```