### PR TITLE
Port acme_r2d2 example agent to updated runtime

### DIFF
--- a/example_agents/acme_r2d2/agentos.ini
+++ b/example_agents/acme_r2d2/agentos.ini
@@ -13,8 +13,8 @@ class_name = R2D2Policy
 dependencies = ["environment", "network", "dataset"]
 
 [network]
-file_path = ./policy.py
-class_name = BasicRNN
+file_path = ./network.py
+class_name = R2D2Network
 dependencies = ["environment"]
 
 [dataset]

--- a/example_agents/acme_r2d2/dataset.py
+++ b/example_agents/acme_r2d2/dataset.py
@@ -12,11 +12,8 @@ from dm_env import StepType
 
 class ReverbDataset(agentos.Dataset):
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    def init(self, **params):
-        self.parameters = params
-        initial_state = self.network.initial_state(1)
+        self.parameters = kwargs
+        initial_state = self.network.rnn.initial_state(1)
         extra_spec = {
             "core_state": tf2_utils.squeeze_batch_dim(initial_state),
         }
@@ -66,8 +63,8 @@ class ReverbDataset(agentos.Dataset):
         mean_priority = tf.reduce_mean(abs_errors, axis=0)
         max_priority = tf.reduce_max(abs_errors, axis=0)
         priorities = (
-            self.parameters.max_priority_weight * max_priority
-            + (1 - self.parameters.max_priority_weight) * mean_priority
+            self.parameters["max_priority_weight"] * max_priority
+            + (1 - self.parameters["max_priority_weight"]) * mean_priority
         )
 
         # Compute priorities and add an op to update them on the reverb

--- a/example_agents/acme_r2d2/network.py
+++ b/example_agents/acme_r2d2/network.py
@@ -1,0 +1,51 @@
+from acme.tf import networks
+import sonnet as snt
+from pathlib import Path
+import tensorflow as tf
+
+
+class R2D2Network:
+    def __init__(self, **kwargs):
+        self.backing_dir = kwargs["backing_dir"]
+        self.rnn = BasicRNN(self.environment)
+
+    # https://github.com/deepmind/sonnet#tensorflow-checkpointing
+    def save_tensorflow(self):
+        checkpoint = tf.train.Checkpoint(module=self.rnn)
+        checkpoint.save(Path(self.backing_dir) / "network")
+
+    def restore_tensorflow(self):
+        checkpoint = tf.train.Checkpoint(module=self.rnn)
+        latest = tf.train.latest_checkpoint(self.backing_dir)
+        if latest is not None:
+            print("AgentOS: Restoring policy network from checkpoint")
+            checkpoint.restore(latest)
+        else:
+            print("AgentOS: No checkpoint found for policy network")
+
+
+# BasicRNN, taken from r2d2 test
+# https://github.com/deepmind/acme/blob/master/acme/agents/tf/r2d2/agent_test.py
+class BasicRNN(networks.RNNCore):
+    def __init__(self, environment):
+        super().__init__(name="basic_r2d2_RNN_network")
+        self._net = snt.DeepRNN(
+            [
+                snt.Flatten(),
+                snt.VanillaRNN(16),
+                snt.VanillaRNN(16),
+                snt.VanillaRNN(16),
+                snt.nets.MLP(
+                    [16, 16, environment.get_spec().actions.num_values]
+                ),
+            ]
+        )
+
+    def __call__(self, inputs, state):
+        return self._net(inputs, state)
+
+    def initial_state(self, batch_size: int, **kwargs):
+        return self._net.initial_state(batch_size)
+
+    def unroll(self, inputs, state, sequence_length):
+        return snt.static_unroll(self._net, inputs, state, sequence_length)

--- a/example_agents/acme_r2d2/parameters.yaml
+++ b/example_agents/acme_r2d2/parameters.yaml
@@ -6,15 +6,15 @@ agent:
         test_every: True
         test_num_episodes: 1
 dataset:
-    init:
+    __init__:
         max_replay_size: 500
         priority_exponent: 0.6
         max_priority_weight: 0.9
 policy:
-    init:
+    __init__:
         epsilon: 0.01
 trainer:
-    init:
+    __init__:
         learning_rate: 0.001
         adam_epsilon: 0.001
         burn_in_length: 2

--- a/example_agents/acme_r2d2/policy.py
+++ b/example_agents/acme_r2d2/policy.py
@@ -1,79 +1,23 @@
 from acme.agents.tf import actors
-from acme.tf import networks
 from acme.tf import utils as tf2_utils
 import trfl
 import numpy as np
 import sonnet as snt
-from pathlib import Path
-
-
-# BasicRNN, taken from r2d2 test
-# https://github.com/deepmind/acme/blob/master/acme/agents/tf/r2d2/agent_test.py
-class BasicRNN(networks.RNNCore):
-    def __init__(self):
-        super().__init__(name="basic_r2d2_RNN_network")
-
-    def init(self, backing_dir):
-        self.backing_dir = backing_dir
-        self._net = snt.DeepRNN(
-            [
-                snt.Flatten(),
-                snt.VanillaRNN(16),
-                snt.VanillaRNN(16),
-                snt.VanillaRNN(16),
-                snt.nets.MLP(
-                    [16, 16, self.environment.get_spec().actions.num_values]
-                ),
-            ]
-        )
-
-    def __call__(self, inputs, state):
-        return self._net(inputs, state)
-
-    def initial_state(self, batch_size: int, **kwargs):
-        return self._net.initial_state(batch_size)
-
-    def unroll(self, inputs, state, sequence_length):
-        return snt.static_unroll(self._net, inputs, state, sequence_length)
-
-    # https://github.com/deepmind/sonnet#tensorflow-checkpointing
-    # TODO - custom saver/restorer functions
-    # TODO - ONLY works for the demo (Acme on TF) because the dynamic module
-    #        loading in ACR core breaks pickle. Need to figure out a more
-    #        general way to handle this
-    def save_tensorflow(self):
-        import tensorflow as tf
-
-        checkpoint = tf.train.Checkpoint(module=self)
-        checkpoint.save(Path(self.backing_dir) / "network")
-
-    # https://github.com/deepmind/sonnet#tensorflow-checkpointing
-    # Same caveats as save_tensorflow above
-    def restore_tensorflow(self):
-        import tensorflow as tf
-
-        checkpoint = tf.train.Checkpoint(module=self)
-        latest = tf.train.latest_checkpoint(self.backing_dir)
-        if latest is not None:
-            print("AgentOS: Restoring policy network from checkpoint")
-            checkpoint.restore(latest)
-        else:
-            print("AgentOS: No checkpoint found for policy network")
 
 
 class R2D2Policy:
-    def init(self, epsilon, store_lstm_state):
-        self.epsilon = epsilon
-        self.store_lstm_state = store_lstm_state
+    def __init__(self, **kwargs):
+        self.epsilon = kwargs["epsilon"]
+        self.store_lstm_state = kwargs["store_lstm_state"]
         self.network.restore_tensorflow()
         tf2_utils.create_variables(
-            self.network, [self.environment.get_spec().observations]
+            self.network.rnn, [self.environment.get_spec().observations]
         )
 
         def epsilon_greedy_fn(qs):
             return trfl.epsilon_greedy(qs, epsilon=self.epsilon).sample()
 
-        policy_network = snt.DeepRNN([self.network, epsilon_greedy_fn])
+        policy_network = snt.DeepRNN([self.network.rnn, epsilon_greedy_fn])
         ADDER = None
         self.actor = actors.RecurrentActor(
             policy_network,


### PR DESCRIPTION
Acme R2D2 agent works with the the updated runtime (see issue discussed [here](https://github.com/agentos-project/agentos/pull/169#pullrequestreview-777292063)).  Main change is to wrap the sonnet network in a component so that it doesn't complain about the `__init__()` trickery.

```
cd example_agents/acme_r2d2/

# Run learn
 agentos run agent --entry-point learn --param-file parameters.yaml

# Run evaluate
 agentos run agent --entry-point evaluate --param-file parameters.yaml
```