### PR TITLE
Implementation of Component Registry v2

### DIFF
--- a/agentos/registry.py
+++ b/agentos/registry.py
@@ -1,0 +1,82 @@
+import os
+import mlflow
+import subprocess
+from pathlib import Path
+from utils import DUMMY_DEV_REGISTRY
+from component import Component
+
+
+class Registry:
+    def __init__(self):
+        self.registry = DUMMY_DEV_REGISTRY
+        self.aos_cache_dir = Path.home() / ".agentos_cache"
+        self.instantiated_components = {}
+
+    def get_component(self, name):
+        if name in self.instantiated_components:
+            return self.instantiated_components[name]
+        spec = self.registry["components"][name]
+        local_repo_path = self._clone_repo(spec["repo"])
+        self._checkout_version(local_repo_path, spec["version"])
+        file_path = local_repo_path / spec["file_path"]
+        component = Component.get_from_file(spec["class_name"], file_path)
+        for alias, dep_name in spec["dependencies"].items():
+            dep_component = self.get_component(dep_name)
+            component.add_dependency(dep_component, alias=alias)
+        self.instantiated_components[name] = component
+        return component
+
+    def _clone_repo(self, repo_name):
+        repo = self.registry["repos"][repo_name]
+        assert repo["type"] == "github", f'Uknown repo type: {repo["type"]}'
+        org_name, proj_name = repo["url"].split("/")[-2:]
+        clone_destination = self.aos_cache_dir / org_name / proj_name
+        if not clone_destination.exists():
+            cmd = ["git", "clone", repo["url"], clone_destination]
+            result = subprocess.run(cmd)
+            assert result.returncode == 0, f"Git clone non-zero return: {cmd}"
+        assert clone_destination.exists(), f"Unable to clone {repo['url']}"
+        return clone_destination
+
+    def _checkout_version(self, repo_path, version_string):
+        curr_dir = os.getcwd()
+        os.chdir(repo_path)
+        cmd = ["git", "checkout", "-q", version_string]
+        result = subprocess.run(cmd)
+        assert result.returncode == 0, f"FAILED: {cmd} in {repo_path}"
+        os.chdir(curr_dir)
+
+
+if __name__ == "__main__":
+    params = {
+        "evaluate": {"num_episodes": 50},
+        "learn": {"num_episodes": 100},
+        "__init__": {
+            "discount": 0.99,
+            "sequence_length": 13,
+            "store_lstm_state": True,
+            "replay_period": 40,
+            "batch_size": 32,
+            "max_replay_size": 500,
+            "priority_exponent": 0.6,
+            "max_priority_weight": 0.9,
+            "epsilon": 0.01,
+            "learning_rate": 0.001,
+            "target_update_period": 20,
+            "adam_epsilon": 0.001,
+            "burn_in_length": 2,
+            "n_step": 5,
+            "min_replay_size": 50,
+            "importance_sampling_exponent": 0.2,
+            "clip_grad_norm": None,
+            "samples_per_insert": 32.0,
+        },
+    }
+
+    mlflow.start_run()
+    registry = Registry()
+    component = registry.get_component("acme_r2d2_agent")
+    for fn_name, params in params.items():
+        component.add_params_to_all(fn_name, params)
+    acme_r2d2_agent = component.get_instance()
+    acme_r2d2_agent.evaluate(num_episodes=10)

--- a/agentos/registry.py
+++ b/agentos/registry.py
@@ -19,7 +19,9 @@ class Registry:
         local_repo_path = self._clone_repo(spec["repo"])
         self._checkout_version(local_repo_path, spec["version"])
         file_path = local_repo_path / spec["file_path"]
-        component = Component.get_from_file(spec["class_name"], file_path)
+        component = Component.get_from_file(
+            spec["class_name"], file_path, name=name
+        )
         for alias, dep_name in spec["dependencies"].items():
             dep_component = self.get_component(dep_name)
             component.add_dependency(dep_component, alias=alias)
@@ -49,34 +51,67 @@ class Registry:
 
 if __name__ == "__main__":
     params = {
-        "evaluate": {"num_episodes": 50},
-        "learn": {"num_episodes": 100},
-        "__init__": {
-            "discount": 0.99,
-            "sequence_length": 13,
-            "store_lstm_state": True,
-            "replay_period": 40,
-            "batch_size": 32,
-            "max_replay_size": 500,
-            "priority_exponent": 0.6,
-            "max_priority_weight": 0.9,
-            "epsilon": 0.01,
-            "learning_rate": 0.001,
-            "target_update_period": 20,
-            "adam_epsilon": 0.001,
-            "burn_in_length": 2,
-            "n_step": 5,
-            "min_replay_size": 50,
-            "importance_sampling_exponent": 0.2,
-            "clip_grad_norm": None,
-            "samples_per_insert": 32.0,
+        "acme_r2d2_agent": {
+            "evaluate": {"num_episodes": 50},
+            "learn": {"num_episodes": 100},
+        },
+        "acme_r2d2_dataset": {
+            "__init__": {
+                "batch_size": 32,
+                "discount": 0.99,
+                "max_priority_weight": 0.9,
+                "max_replay_size": 500,
+                "priority_exponent": 0.6,
+                "replay_period": 40,
+                "sequence_length": 13,
+                "store_lstm_state": True,
+            }
+        },
+        "acme_cartpole": {
+            "__init__": {
+                "batch_size": 32,
+                "discount": 0.99,
+                "max_replay_size": 500,
+                "replay_period": 40,
+                "sequence_length": 13,
+                "store_lstm_state": True,
+            }
+        },
+        "acme_r2d2_policy": {
+            "__init__": {
+                "batch_size": 32,
+                "discount": 0.99,
+                "epsilon": 0.01,
+                "max_replay_size": 500,
+                "replay_period": 40,
+                "sequence_length": 13,
+                "store_lstm_state": True,
+            }
+        },
+        "acme_r2d2_trainer": {
+            "__init__": {
+                "adam_epsilon": 0.001,
+                "batch_size": 32,
+                "burn_in_length": 2,
+                "clip_grad_norm": None,
+                "discount": 0.99,
+                "importance_sampling_exponent": 0.2,
+                "learning_rate": 0.001,
+                "max_replay_size": 500,
+                "min_replay_size": 50,
+                "n_step": 5,
+                "replay_period": 40,
+                "samples_per_insert": 32.0,
+                "sequence_length": 13,
+                "store_lstm_state": True,
+                "target_update_period": 20,
+            }
         },
     }
 
     mlflow.start_run()
     registry = Registry()
     component = registry.get_component("acme_r2d2_agent")
-    for fn_name, params in params.items():
-        component.add_params_to_all(fn_name, params)
+    component.add_params(params)
     acme_r2d2_agent = component.get_instance()
     acme_r2d2_agent.evaluate(num_episodes=10)

--- a/agentos/runtime.py
+++ b/agentos/runtime.py
@@ -32,10 +32,9 @@ def run_component(
         params,
         param_file,
     )
-    component = Component.get_from_yaml(
-        component_name, component_spec_file, param_file
-    )
-    component.add_params(entry_point, params)
+    component = Component.get_from_yaml(component_name, component_spec_file)
+    component.parse_param_file(param_file)
+    component.add_params_to_fn(entry_point, params)
     component.call(entry_point)
 
 

--- a/agentos/runtime.py
+++ b/agentos/runtime.py
@@ -35,7 +35,7 @@ def run_component(
     component = Component.get_from_yaml(component_name, component_spec_file)
     component.parse_param_file(param_file)
     component.add_params_to_fn(entry_point, params)
-    component.call(entry_point)
+    component.run(entry_point)
 
 
 # TODO - move into and integrate with ComponentNamespace + Component

--- a/agentos/utils.py
+++ b/agentos/utils.py
@@ -1,1 +1,127 @@
+import pprint
+import yaml
+from pathlib import Path
+
 MLFLOW_EXPERIMENT_ID = "0"
+
+
+DUMMY_DEV_REGISTRY = {
+    "components": {
+        "acme_cartpole": {
+            "class_name": "CartPole",
+            "dependencies": {},
+            "file_path": "example_agents/acme_r2d2/../acme_dqn/environment.py",
+            "repo": "dev_repo",
+            "version": "262fa00",
+        },
+        "acme_r2d2_agent": {
+            "class_name": "AcmeR2D2Agent",
+            "dependencies": {
+                "dataset": "acme_r2d2_dataset",
+                "environment": "acme_cartpole",
+                "network": "acme_r2d2_network",
+                "policy": "acme_r2d2_policy",
+                "tracker": "acme_tracker",
+                "trainer": "acme_r2d2_trainer",
+            },
+            "file_path": "example_agents/acme_r2d2/agent.py",
+            "repo": "dev_repo",
+            "version": "262fa00",
+        },
+        "acme_r2d2_dataset": {
+            "class_name": "ReverbDataset",
+            "dependencies": {
+                "environment": "acme_cartpole",
+                "network": "acme_r2d2_network",
+            },
+            "file_path": "example_agents/acme_r2d2/dataset.py",
+            "repo": "dev_repo",
+            "version": "262fa00",
+        },
+        "acme_r2d2_network": {
+            "class_name": "R2D2Network",
+            "dependencies": {
+                "environment": "acme_cartpole",
+                "tracker": "acme_tracker",
+            },
+            "file_path": "example_agents/acme_r2d2/network.py",
+            "repo": "dev_repo",
+            "version": "262fa00",
+        },
+        "acme_r2d2_policy": {
+            "class_name": "R2D2Policy",
+            "dependencies": {
+                "dataset": "acme_r2d2_dataset",
+                "environment": "acme_cartpole",
+                "network": "acme_r2d2_network",
+            },
+            "file_path": "example_agents/acme_r2d2/policy.py",
+            "repo": "dev_repo",
+            "version": "262fa00",
+        },
+        "acme_r2d2_trainer": {
+            "class_name": "R2D2Trainer",
+            "dependencies": {
+                "dataset": "acme_r2d2_dataset",
+                "environment": "acme_cartpole",
+                "network": "acme_r2d2_network",
+            },
+            "file_path": "example_agents/acme_r2d2/trainer.py",
+            "repo": "dev_repo",
+            "version": "262fa00",
+        },
+        "acme_tracker": {
+            "class_name": "AcmeTracker",
+            "dependencies": {},
+            "file_path": "example_agents/acme_r2d2/../acme_dqn/tracker.py",
+            "repo": "dev_repo",
+            "version": "262fa00",
+        },
+    },
+    "repos": {
+        "dev_repo": {
+            "type": "github",
+            "url": "https://github.com/agentos-project/agentos",
+        },
+        "local_dir": {"path": ".", "type": "local"},
+    },
+}
+
+
+def generate_dummy_dev_registry():
+    VERSION_STRING = "262fa00"
+    R2D2_PATH_PREFIX = Path("example_agents") / Path("acme_r2d2")
+    RENAME_MAP = {
+        "agent": "acme_r2d2_agent",
+        "dataset": "acme_r2d2_dataset",
+        "environment": "acme_cartpole",
+        "network": "acme_r2d2_network",
+        "policy": "acme_r2d2_policy",
+        "tracker": "acme_tracker",
+        "trainer": "acme_r2d2_trainer",
+    }
+    aos_root = Path(__file__).parent.parent
+    r2d2_spec = aos_root / R2D2_PATH_PREFIX / "agentos.yaml"
+    with open(r2d2_spec) as file_in:
+        registry = yaml.safe_load(file_in)
+    registry.get("repos")["dev_repo"] = {
+        "type": "github",
+        "url": "https://github.com/agentos-project/agentos",
+    }
+    renamed = {}
+    for component_name, spec in registry.get("components").items():
+        assert spec["repo"] == "local_dir"
+        spec["repo"] = "dev_repo"
+        spec["file_path"] = str(R2D2_PATH_PREFIX / Path(spec["file_path"]))
+        spec["version"] = VERSION_STRING
+        renamed[RENAME_MAP[component_name]] = spec
+        renamed_dependencies = {}
+        for alias, dep_name in spec.get("dependencies", {}).items():
+            renamed_dependencies[alias] = RENAME_MAP[dep_name]
+        spec["dependencies"] = renamed_dependencies
+    registry["components"] = renamed
+    pprint.pprint(registry)
+
+
+if __name__ == "__main__":
+    generate_dummy_dev_registry()


### PR DESCRIPTION
This PR makes the following possible in the REPL (modulo some parameter issues noted below):

```python
from agentos.registry import Registry
registry = Registry()
component = registry.get_component("acme_r2d2_agent")
acme_r2d2_agent = component.get_instance()
acme_r2d2_agent.evaluate(num_episodes=10)
```

This code works against a dummy registry that associates the name `acme_r2d2_agent` with the corresponding example agent in AgentOS available on Github.  It clones the repo and does the necessary DAG setup to enable the `evaluate()` call.

To run this demo: `python agentos/registry.py`

Caveats:
* We don't handle requirements so you need to have the Acme R2D2 requirements installed in your env.
* The parameter system still needs refinement.  In a complex agent like this, it's not clear how to best to pass params to components deep in the graph (esp. if they have required params).
* I think the points for MLFlow integration are becoming clearer, but they're currently not implemented in the runtime.