### PR TITLE
Ability to pin a version of a spec file

### DIFF
--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -154,12 +154,12 @@ def run(
 @agentos_cmd.command()
 @_arg_component_name
 @_option_component_spec_file
-def pin(component_name, component_spec_file):
+def freeze(component_name, component_spec_file):
     """
     Creates a version of ``component_spec_file`` for Component
-    ``component_name`` where all Components in the dependency tree are pinned
-    to a specific git commit.  The resulting ``component_spec_file`` can be run
-    on any machine with AgentOS installed.
+    ``component_name`` where all Components in the dependency tree are
+    associated with a specific git commit.  The resulting
+    ``component_spec_file`` can be run on any machine with AgentOS installed.
 
     The requirements for pinning a Component spec are as follows:
         * All Components in the dependency tree must be in git repos
@@ -169,10 +169,8 @@ def pin(component_name, component_spec_file):
         * There are no uncommitted changes in the local repo
     """
     component = Component.get_from_yaml(component_name, component_spec_file)
-    pinned_spec = component.get_pinned_component_spec()
-    with open(component_spec_file, "w") as file_out:
-        yaml.dump(pinned_spec, file_out)
-    print(f"Pinned spec written to {Path(component_spec_file).absolute()}")
+    frozen_spec = component.get_frozen_component_spec()
+    print(yaml.dump(frozen_spec))
 
 
 # Copied from https://github.com/mlflow/mlflow/blob/3958cdf9664ade34ebcf5960bee215c80efae992/mlflow/cli.py#L188 # noqa: E501

--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -4,6 +4,7 @@ The CLI allows creation of a simple template agent.
 """
 import os
 import sys
+import yaml
 import click
 from datetime import datetime
 from pathlib import Path
@@ -28,6 +29,16 @@ _arg_component_name = click.argument(
 )
 
 _arg_dir_names = click.argument("dir_names", nargs=-1, metavar="DIR_NAMES")
+
+
+_option_component_spec_file = click.option(
+    "--component-spec-file",
+    "-s",
+    type=click.Path(exists=True),
+    default="./agentos.yaml",
+    help="Path to component spec file (agentos.yaml).",
+)
+
 
 _option_agent_name = click.option(
     "--agent-name",
@@ -98,13 +109,7 @@ def init(dir_names, agent_name, agentos_dir):
 
 @agentos_cmd.command()
 @_arg_component_name
-@click.option(
-    "--component-spec-file",
-    "-s",
-    type=click.Path(exists=True),
-    default="./agentos.yaml",
-    help="Path to component spec file (agentos.yaml).",
-)
+@_option_component_spec_file
 @click.option(
     "--entry-point",
     metavar="ENTRY_POINT",
@@ -144,6 +149,30 @@ def run(
     parameters = ParameterSet.get_from_file(param_file)
     parameters.update(component_name, entry_point, param_dict)
     component.run(entry_point, parameters)
+
+
+@agentos_cmd.command()
+@_arg_component_name
+@_option_component_spec_file
+def pin(component_name, component_spec_file):
+    """
+    Creates a version of ``component_spec_file`` for Component
+    ``component_name`` where all Components in the dependency tree are pinned
+    to a specific git commit.  The resulting ``component_spec_file`` can be run
+    on any machine with AgentOS installed.
+
+    The requirements for pinning a Component spec are as follows:
+        * All Components in the dependency tree must be in git repos
+        * Those git repos must have GitHub as their origin
+        * The current local branch and its counterpart on origin are at
+          the same commit
+        * There are no uncommitted changes in the local repo
+    """
+    component = Component.get_from_yaml(component_name, component_spec_file)
+    pinned_spec = component.get_pinned_component_spec()
+    with open(component_spec_file, "w") as file_out:
+        yaml.dump(pinned_spec, file_out)
+    print(f"Pinned spec written to {Path(component_spec_file).absolute()}")
 
 
 # Copied from https://github.com/mlflow/mlflow/blob/3958cdf9664ade34ebcf5960bee215c80efae992/mlflow/cli.py#L188 # noqa: E501

--- a/agentos/repo.py
+++ b/agentos/repo.py
@@ -25,8 +25,8 @@ class Repo:
     is located.
     """
 
-    @classmethod
-    def from_spec(cls, name, spec):
+    @staticmethod
+    def from_spec(name, spec):
         if spec["type"] == RepoType.LOCAL.value:
             return LocalRepo(name=name, file_path=spec["path"])
         elif spec["type"] == RepoType.GITHUB.value:
@@ -67,6 +67,7 @@ class GitHubRepo(Repo):
     def __init__(self, name: str, url: str):
         self.name = name
         self.type = RepoType.GITHUB
+        # https repo link allows for cloning without unlocking your GitHub keys
         url = url.replace("git@github.com:", "https://github.com/")
         self.url = url
         self.local_repo_path = None

--- a/agentos/utils.py
+++ b/agentos/utils.py
@@ -1,3 +1,6 @@
+from dulwich import porcelain
+from dulwich.repo import Repo
+from dulwich.errors import NotGitRepository
 import pprint
 import yaml
 import mlflow
@@ -17,6 +20,103 @@ def log_data_as_yaml_artifact(name: str, data: dict):
         file_out.write(yaml.safe_dump(data))
     mlflow.log_artifact(artifact_path)
     shutil.rmtree(tmp_dir_path)
+
+
+def get_prefixed_path_from_repo_root(component_path):
+    """
+    Finds the 'component_path' relative to the repo containing the Component.
+    For example, if ``component_path`` is:
+
+    ```
+    /foo/bar/baz/my_component.py
+    ```
+
+    and a git repo lives in:
+
+    ```
+    /foo/bar/.git/
+    ```
+
+    then this would return:
+
+    ```
+    baz/my_component.py
+    ```
+    """
+    name = component_path.name
+    curr_path = component_path.parent
+    path_prefix = Path()
+    while curr_path != Path(curr_path.root):
+        try:
+            Repo(curr_path)
+            return path_prefix / name
+        except NotGitRepository:
+            path_prefix = curr_path.name / path_prefix
+            curr_path = curr_path.parent
+
+
+def get_version_from_git(component_path):
+    """
+    Given a path to a Component, this returns a git hash and GitHub repo
+    URL where the current version of the Component is publicly accessible.
+    """
+    component_path = Path(component_path).absolute()
+    assert component_path.exists(), f"Path {component_path} does not exist"
+
+    try:
+        repo = Repo.discover(component_path)
+    except NotGitRepository:
+        raise Exception(f"No git repo with Component found: {component_path}")
+
+    REMOTE_GIT_PREFIX = "refs/remotes"
+    remote, url = porcelain.get_remote_repo(repo)
+    branch = porcelain.active_branch(repo).decode("UTF-8")
+    full_id = f"{REMOTE_GIT_PREFIX}/{remote}/{branch}".encode("UTF-8")
+    curr_remote_hash = repo.refs.as_dict()[full_id].decode("UTF-8")
+    curr_head_hash = repo.head().decode("UTF-8")
+
+    if "github.com" not in url:
+        raise Exception(f"Remote must be on github, not {url}")
+
+    if curr_head_hash != curr_remote_hash:
+        print(f"\nBranch {remote}/{branch} current commit differs from local:")
+        print(f"\t{remote}/{branch}: {curr_remote_hash}")
+        print(f"\tlocal/{branch}: {curr_head_hash}\n")
+        raise Exception(
+            f"Push your changes to {remote}/{branch} before pinning"
+        )
+
+    # Adapted from
+    # https://github.com/dulwich/dulwich/blob/master/dulwich/porcelain.py#L1200
+    # 1. Get status of staged
+    tracked_changes = porcelain.get_tree_changes(repo)
+    # 2. Get status of unstaged
+    index = repo.open_index()
+    normalizer = repo.get_blob_normalizer()
+    filter_callback = normalizer.checkin_normalize
+    unstaged_changes = list(
+        porcelain.get_unstaged_changes(index, repo.path, filter_callback)
+    )
+
+    uncommitted_changes_exist = (
+        len(unstaged_changes) > 0
+        or len(tracked_changes["add"]) > 0
+        or len(tracked_changes["delete"]) > 0
+        or len(tracked_changes["modify"]) > 0
+    )
+    if uncommitted_changes_exist:
+        print(
+            f"\nUncommitted changes: {tracked_changes} or {unstaged_changes}\n"
+        )
+        raise Exception("Commit all changes before pinning")
+
+    # If we are here, then:
+    #   * The Component is in a git repo
+    #   * The origin of this repo is GitHub
+    #   * The current local branch and corresponding remote branch are at the
+    #     same commit
+    #   * There are no uncommitted changes locally
+    return url, curr_head_hash
 
 
 DUMMY_DEV_REGISTRY = {

--- a/tests/example_agents/test_acme_dqn.py
+++ b/tests/example_agents/test_acme_dqn.py
@@ -7,9 +7,10 @@ from tests.utils import is_linux
 @pytest.mark.skipif(not is_linux(), reason="Acme only available on posix")
 def test_acme_dqn_agent(venv):
     run_component_in_dir(
-        ACME_DQN_AGENT_DIR,
-        venv,
-        "agent",
+        dir_name=ACME_DQN_AGENT_DIR,
+        venv=venv,
+        component_name="agent",
+        agentos_cmd="run",
         entry_points=["evaluate", "learn"],
         entry_point_params=[
             "--param-file parameters.yaml -Pnum_episodes=1",

--- a/tests/example_agents/test_acme_r2d2.py
+++ b/tests/example_agents/test_acme_r2d2.py
@@ -7,9 +7,10 @@ from tests.utils import is_linux
 @pytest.mark.skipif(not is_linux(), reason="Acme only available on posix")
 def test_acme_r2d2_agent(venv):
     run_component_in_dir(
-        ACME_R2D2_AGENT_DIR,
-        venv,
-        "agent",
+        dir_name=ACME_R2D2_AGENT_DIR,
+        venv=venv,
+        component_name="agent",
+        agentos_cmd="run",
         entry_points=["evaluate", "learn"],
         entry_point_params=[
             "--param-file parameters.yaml -Pnum_episodes=1",

--- a/tests/example_agents/test_gh_sb3.py
+++ b/tests/example_agents/test_gh_sb3.py
@@ -4,9 +4,10 @@ from tests.utils import GH_SB3_AGENT_DIR
 
 def test_sb3_agent(venv):
     run_component_in_dir(
-        GH_SB3_AGENT_DIR,
-        venv,
-        "agent",
+        dir_name=GH_SB3_AGENT_DIR,
+        venv=venv,
+        component_name="agent",
+        agentos_cmd="run",
         entry_points=["evaluate", "learn"],
         entry_point_params=[
             "-Pn_eval_episodes=1",

--- a/tests/example_agents/test_others.py
+++ b/tests/example_agents/test_others.py
@@ -6,11 +6,13 @@ from tests.utils import EVOLUTIONARY_AGENT_DIR
 
 
 @pytest.mark.skip(reason="TODO: port run_component to new abstractions")
-def test_rl_agents(virtualenv):
+def test_rl_agents(venv):
     run_component_in_dir(
-        RL_AGENTS_DIR,
-        virtualenv,
-        "ReinforceAgent",
+        dir_name=RL_AGENTS_DIR,
+        venv=venv,
+        component_name="ReinforceAgent",
+        agentos_cmd="run",
+        entry_points=["evaluate"],
     )
     # TODO: add tests for DQN, RandomTFAgent
     # from example_agents.rl_agents.dqn_agent import DQNAgent
@@ -20,10 +22,22 @@ def test_rl_agents(virtualenv):
 
 
 @pytest.mark.skip(reason="TODO: port run_component to new abstractions")
-def test_predictive_coding(virtualenv):
-    run_component_in_dir(PREDICTIVE_CODING_AGENT_DIR, virtualenv, "agent")
+def test_predictive_coding(venv):
+    run_component_in_dir(
+        dir_name=PREDICTIVE_CODING_AGENT_DIR,
+        venv=venv,
+        component_name="agent",
+        agentos_cmd="run",
+        entry_points=["evaluate"],
+    )
 
 
 @pytest.mark.skip(reason="TODO: port run_component to new abstractions")
-def test_evolutionary_agent(virtualenv):
-    run_component_in_dir(EVOLUTIONARY_AGENT_DIR, virtualenv, "agent")
+def test_evolutionary_agent(venv):
+    run_component_in_dir(
+        dir_name=EVOLUTIONARY_AGENT_DIR,
+        venv=venv,
+        component_name="agent",
+        agentos_cmd="run",
+        entry_points=["evaluate"],
+    )

--- a/tests/example_agents/test_rllib.py
+++ b/tests/example_agents/test_rllib.py
@@ -4,9 +4,10 @@ from tests.utils import RLLIB_AGENT_DIR
 
 def test_rllib_agent(venv):
     run_component_in_dir(
-        RLLIB_AGENT_DIR,
-        venv,
-        "agent",
+        dir_name=RLLIB_AGENT_DIR,
+        venv=venv,
+        component_name="agent",
+        agentos_cmd="run",
         entry_points=["evaluate", "learn"],
         entry_point_params=["", "-P num_iterations=5"],
     )

--- a/tests/example_agents/test_sb3.py
+++ b/tests/example_agents/test_sb3.py
@@ -4,9 +4,10 @@ from tests.utils import SB3_AGENT_DIR
 
 def test_sb3_agent(venv):
     run_component_in_dir(
-        SB3_AGENT_DIR,
-        venv,
-        "agent",
+        dir_name=SB3_AGENT_DIR,
+        venv=venv,
+        component_name="agent",
+        agentos_cmd="run",
         entry_points=["evaluate", "learn"],
         entry_point_params=[
             "-Pn_eval_episodes=1",

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,4 +1,8 @@
 """Test suite for AgentOS Component."""
+import os
+import subprocess
+from unittest.mock import patch
+from unittest.mock import DEFAULT
 from agentos import Component
 
 
@@ -24,3 +28,26 @@ def test_component_repl_demo():
 
     # Instantiate a SimpleAgent and run reset_env() method
     agent_component.run("reset_env")
+
+
+def test_component_freezing(tmpdir):
+    subprocess.run(["agentos", "init"], cwd=tmpdir, check=True)
+    curr_dir = os.getcwd()
+    os.chdir(tmpdir)
+    try:
+        c = Component.get_from_yaml("agent", "agentos.yaml")
+        with patch.multiple(
+            "agentos.component",
+            get_version_from_git=DEFAULT,
+            get_prefixed_path_from_repo_root=DEFAULT,
+        ) as mocks:
+            mocks["get_version_from_git"].return_value = (
+                "https://example.com",
+                "test_freezing_version",
+            )
+            mocks[
+                "get_prefixed_path_from_repo_root"
+            ].return_value = "freeze/test.py"
+            c.get_frozen_component_spec()
+    finally:
+        os.chdir(curr_dir)


### PR DESCRIPTION
This PR adds functionality to take a Component DAG and pin the version of each Component to a publicly available version on GitHub.  The resulting spec can then be run on any machine where AgentOS is installed.

## Demo

```bash
cd example_agents/sb3_agent/

# Run the local version of the SB3 PPO example agent
agentos run agent

# Pin the version of SB3 PPO example agent
agentos pin agent

# Copy the updated agentos.yaml into another directory
mkdir ~/demo
cp agentos.yaml ~/demo/

# Run the agent from the updated spec that has AgentOS pull the Component tree from GitHub
cd ~/demo
agentos run agent
```

## Caveats

Before pinning, we require that each Component in the dependency tree:
* Be in a repo (not necessarily the same repo) whose `origin` is a GitHub URL
* That the local repo branch has a corresponding branch on `origin` and both branches are at the same commit
* That there are no uncommitted changes in the repo