### PR TITLE
Run fixes and tweaks

### DIFF
--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -166,7 +166,7 @@ def run(
 @agentos_cmd.command()
 @_arg_optional_entity_id
 @_option_registry_file
-def status(entity_id, component_spec_file):
+def status(entity_id, registry_file):
     """
     ENTITY_ID can be a Component name or a Run ID.
     """
@@ -175,7 +175,7 @@ def status(entity_id, component_spec_file):
     else:
         Run.print_all_status()
         if entity_id:
-            component = Component.get_from_yaml(entity_id, component_spec_file)
+            component = Component.from_registry_file(registry_file, entity_id)
             component.print_status_tree()
 
 

--- a/agentos/component.py
+++ b/agentos/component.py
@@ -311,11 +311,12 @@ class Component:
             registry.add_component_spec(c.to_spec())
             try:
                 repo_spec = registry.get_repo_spec(c.repo.name)
-                if repo_spec != c.repo.to_spec():
+                if repo_spec != c.repo.to_spec()[c.repo.name]:
                     raise RegistryException(
-                        f"A Repo with identifier {c.repo.name} already exists"
+                        f"A Repo with identifier {c.repo.name} already exists "
                         f"in this registry that differs from the one referred "
-                        f"to by component {c.identifier}."
+                        f"to by component {c.identifier}: {repo_spec} vs "
+                        f"{c.repo.to_spec()[c.repo.name]}"
                     )
             except LookupError:
                 # Repo not yet registered, so so add it to this registry.
@@ -354,9 +355,9 @@ class Component:
         rich_print(tree)
 
     def get_status_tree(self, parent_tree: Tree = None) -> Tree:
-        self_tree = Tree(f"Component: {self.full_name}")
+        self_tree = Tree(f"Component: {self.identifier.full}")
         if parent_tree is not None:
             parent_tree.add(self_tree)
-        for dep_attr_name, dep_component in self._dependencies.items():
+        for dep_attr_name, dep_component in self.dependencies.items():
             dep_component.get_status_tree(parent_tree=self_tree)
         return self_tree

--- a/agentos/run_manager.py
+++ b/agentos/run_manager.py
@@ -184,7 +184,7 @@ class RunContextManager:
     def _check_component_exists_in_run(self, role_type: str) -> None:
         run = Run.active_run()
         artifacts_dir = run.get_artifacts_dir_path()
-        spec_path = artifacts_dir / Run.SPEC_KEY
+        spec_path = artifacts_dir / Run.REG_KEY
         names = [
             Component.Identifier.from_str(c_id).name
             for c_id in Registry.from_yaml(spec_path)

--- a/web/registry/models.py
+++ b/web/registry/models.py
@@ -171,7 +171,6 @@ class Component(TimeStampedModel):
         self_deps = ComponentDependency.objects.filter(
             depender=self
         ).distinct()
-        print("FOOOOOOOOOOOO")
         for self_dep in self_deps:
             if self_dep.attribute_name not in other_spec["dependencies"]:
                 return False
@@ -180,7 +179,6 @@ class Component(TimeStampedModel):
             ]
             if other_dep_name != self_dep.dependee.full_name:
                 return False
-        print("BARRRRRRRRR")
         return True
 
 
@@ -194,8 +192,6 @@ class Repo(TimeStampedModel):
     @staticmethod
     def create_from_dict(repo_spec_dict: Dict) -> List:
         repos = []
-        print(repo_spec_dict)
-        print(type(repo_spec_dict))
         for name, repo in repo_spec_dict.items():
             if "github.com" not in repo["url"]:
                 raise ValidationError(

--- a/web/registry/models.py
+++ b/web/registry/models.py
@@ -194,6 +194,8 @@ class Repo(TimeStampedModel):
     @staticmethod
     def create_from_dict(repo_spec_dict: Dict) -> List:
         repos = []
+        print(repo_spec_dict)
+        print(type(repo_spec_dict))
         for name, repo in repo_spec_dict.items():
             if "github.com" not in repo["url"]:
                 raise ValidationError(

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,6 +1,6 @@
 #-e ../
 # agentos>=0.0.7
-https://github.com/nickjalbert/agentos/tarball/nj_run_publish
+https://github.com/agentos-project/agentos/tarball/master
 asgiref==3.4.1
 black==21.8b0
 certifi==2021.5.30


### PR DESCRIPTION
A few small fixes found during my review of https://github.com/nickjalbert/agentos/pull/8

Highlights:

* Change `Repo.to_spec()` to be a two-level dict of form `{repo_name: {...repo_info...}}` instead of one-level dict of form `{name: repo_name, ...}`.  This harmonizes it with `Component.to_spec()`.  I think this was what `Registry` was expecting because otherwise the `Registry.add_repo_spec()` implementation would probably break in a surprising way if we had multiple repos.
* Port `agentos status` command to the new registry implementation
  * TODO: add some tests for this command
* Update the Run tracking code that previously froze the component spec to now freeze the registry which includes the root component
* Handle a new way for the porcelain-git interface logic to fail
* Update the web dependency on AgentOS