### PR TITLE
Allow easy swapping of target branch for tests that use code from github

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,6 +155,7 @@ repo to use when testing.
 
 If you make changes to code that is fetched from github for use by tests, then
 please follow this process for your PR:
+
 1. While doing development, change the ``TESTING_GITHUB_REPO`` and/or
    ``TESTING_BRANCH_NAME`` global variables in ``agentos/utils.py``
    to point to a version of your PR branch that you've pushed to

--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,27 @@ To run website tests::
   cd web # the web directory contained in project root
   python manage.py test
 
+Note that some tests (e.g., see ``web/registry/tests/test_integration.py``)
+test functionality for interacting with github repositories by fetching code
+from https://github.com/agentos-project/agentos. Where possible, in order to
+make it easy to have those tests run against code in a github repo that you can
+change during development without disrupting other PRs, the test code uses
+global variables defined in ``agentos/utils.py`` to decide which github
+repo to use when testing.
+
+When that is necessary, the process is as follows:
+1. While doing development, change the ``TESTING_GITHUB_REPO`` and/or
+   ``TESTING_BRANCH_NAME`` global variables in ``agentos/utils.py``
+   to point to a version of your PR branch that you've pushed to
+   github. We recommend commenting out the default "prod" values of these
+   variables so that you can uncomment them in the next step when the PR
+   is approved for merge.
+2. After your PR is approved and right before it is merged, push the branch
+   you used during testing to the ``test_prod`` branch of the agentos-project
+   account ``https://github.com/agentos-project/agentos.git``. And then update
+   the variables in ``agentos/utils.py`` (you should be able to just uncomment
+   the lines you commented out in step 1 above, and delete the lines you added).
+
 
 Building Docs
 =============

--- a/README.rst
+++ b/README.rst
@@ -153,7 +153,8 @@ change during development without disrupting other PRs, the test code uses
 global variables defined in ``agentos/utils.py`` to decide which github
 repo to use when testing.
 
-When that is necessary, the process is as follows:
+If you make changes to code that is fetched from github for use by tests, then
+please follow this process for your PR:
 1. While doing development, change the ``TESTING_GITHUB_REPO`` and/or
    ``TESTING_BRANCH_NAME`` global variables in ``agentos/utils.py``
    to point to a version of your PR branch that you've pushed to

--- a/documentation/includes/developing.rst
+++ b/documentation/includes/developing.rst
@@ -81,6 +81,27 @@ To run website tests::
   cd web # the web directory contained in project root
   python manage.py test
 
+Note that some tests (e.g., see ``web/registry/tests/test_integration.py``)
+test functionality for interacting with github repositories by fetching code
+from https://github.com/agentos-project/agentos. Where possible, in order to
+make it easy to have those tests run against code in a github repo that you can
+change during development without disrupting other PRs, the test code uses
+global variables defined in ``agentos/utils.py`` to decide which github
+repo to use when testing.
+
+When that is necessary, the process is as follows:
+1. While doing development, change the ``TESTING_GITHUB_REPO`` and/or
+   ``TESTING_BRANCH_NAME`` global variables in ``agentos/utils.py``
+   to point to a version of your PR branch that you've pushed to
+   github. We recommend commenting out the default "prod" values of these
+   variables so that you can uncomment them in the next step when the PR
+   is approved for merge.
+2. After your PR is approved and right before it is merged, push the branch
+   you used during testing to the ``test_prod`` branch of the agentos-project
+   account ``https://github.com/agentos-project/agentos.git``. And then update
+   the variables in ``agentos/utils.py`` (you should be able to just uncomment
+   the lines you commented out in step 1 above, and delete the lines you added).
+
 
 Building Docs
 =============

--- a/documentation/includes/developing.rst
+++ b/documentation/includes/developing.rst
@@ -91,6 +91,7 @@ repo to use when testing.
 
 If you make changes to code that is fetched from github for use by tests, then
 please follow this process for your PR:
+
 1. While doing development, change the ``TESTING_GITHUB_REPO`` and/or
    ``TESTING_BRANCH_NAME`` global variables in ``agentos/utils.py``
    to point to a version of your PR branch that you've pushed to

--- a/documentation/includes/developing.rst
+++ b/documentation/includes/developing.rst
@@ -89,7 +89,8 @@ change during development without disrupting other PRs, the test code uses
 global variables defined in ``agentos/utils.py`` to decide which github
 repo to use when testing.
 
-When that is necessary, the process is as follows:
+If you make changes to code that is fetched from github for use by tests, then
+please follow this process for your PR:
 1. While doing development, change the ``TESTING_GITHUB_REPO`` and/or
    ``TESTING_BRANCH_NAME`` global variables in ``agentos/utils.py``
    to point to a version of your PR branch that you've pushed to

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -31,16 +31,17 @@ def test_flatten_spec():
 def test_flatten_versioned_spec():
     reg = Registry.from_yaml(GH_SB3_AGENT_DIR / "components.yaml")
     rand_comp_spec = reg.get_component_spec("agent", "test_staging")
-    assert "agent==test_staging" in rand_comp_spec.keys()
-    assert rand_comp_spec["agent==test_staging"]["repo"] == "aos_github"
+    full_comp_id = f"agent==test_staging"
+    assert full_comp_id in rand_comp_spec.keys()
+    assert rand_comp_spec[full_comp_id]["repo"] == "aos_github"
 
     flattened = flatten_spec(rand_comp_spec)
-    assert flattened["identifier"] == "agent==test_staging"
+    assert flattened["identifier"] == full_comp_id
     assert flattened["name"] == "agent"
     assert flattened["version"] == "test_staging"
 
     nested = unflatten_spec(flattened)
-    assert "agent==test_staging" in nested.keys()
+    assert full_comp_id in nested.keys()
     assert "name" not in nested.keys()
     assert "name" not in nested.values()
     assert "version" not in nested.keys()
@@ -48,5 +49,5 @@ def test_flatten_versioned_spec():
 
     # make sure we used deepcopy
     flattened["repo"] = "update_repo"
-    assert rand_comp_spec["agent==test_staging"]["repo"] == "aos_github"
-    assert nested["agent==test_staging"]["repo"] == "aos_github"
+    assert rand_comp_spec[full_comp_id]["repo"] == "aos_github"
+    assert nested[full_comp_id]["repo"] == "aos_github"

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -31,7 +31,7 @@ def test_flatten_spec():
 def test_flatten_versioned_spec():
     reg = Registry.from_yaml(GH_SB3_AGENT_DIR / "components.yaml")
     rand_comp_spec = reg.get_component_spec("agent", "test_staging")
-    full_comp_id = f"agent==test_staging"
+    full_comp_id = "agent==test_staging"
     assert full_comp_id in rand_comp_spec.keys()
     assert rand_comp_spec[full_comp_id]["repo"] == "aos_github"
 

--- a/tests/test_web_registry.py
+++ b/tests/test_web_registry.py
@@ -2,6 +2,7 @@ import pytest
 from agentos.registry import WebRegistry
 from agentos.component import Component
 from agentos.repo import Repo
+from tests.utils import TESTING_BRANCH_NAME
 
 agentos_repo_spec = {
     "AgentOSRepo": {
@@ -60,7 +61,7 @@ def test_web_registry():
     # Test adding a component that we generate from the repo.
     simple_component = Component.from_repo(
         repo,
-        identifier="SimpleComponent==test_staging",
+        identifier=f"SimpleComponent=={TESTING_BRANCH_NAME}",
         class_name="SimpleComponent",
         file_path="tests/test_web_registry.py",
     )
@@ -69,26 +70,27 @@ def test_web_registry():
     web_registry.add_component_spec(simple_component.to_spec())
 
     # Test getting a flattened component (i.e., the one we just added)
-    comp = web_registry.get_component_spec(
-        name="SimpleComponent", version="test_staging", flatten=True
+    flat_comp_spec = web_registry.get_component_spec(
+        name="SimpleComponent", version=TESTING_BRANCH_NAME, flatten=True
     )
-    assert comp["name"] == "SimpleComponent"
-    assert comp["repo"] == "AgentOSRepo"
+    assert flat_comp_spec["name"] == "SimpleComponent"
+    assert flat_comp_spec["repo"] == "AgentOSRepo"
 
     # Test getting an unflattened component (i.e., the one we just added)
-    comp = web_registry.get_component_spec(
-        name="SimpleComponent", version="test_staging", flatten=False
+    nested_comp_spec = web_registry.get_component_spec(
+        name="SimpleComponent", version=TESTING_BRANCH_NAME, flatten=False
     )
-    assert comp["SimpleComponent"]["class_name"] == "SimpleComponent"
-    assert comp["SimpleComponent"]["repo"] == "AgentOSRepo"
+    full_id = f"SimpleComponent=={TESTING_BRANCH_NAME}"
+    assert nested_comp_spec[full_id]["class_name"] == "SimpleComponent"
+    assert nested_comp_spec[full_id]["repo"] == "AgentOSRepo"
 
     # Test adding a ComponentRun
     param_set = {"SimpleComponent": {"add_to_init_member": {"i": 10}}}
-    comp_run = simple_component.run("SimpleComponent", param_set)
+    comp_run = simple_component.run("add_to_init_member", param_set)
     web_registry.add_run_command_spec(comp_run.run_command)
 
 
-# TODO: add a test that publishes a ComponentRun or Compoonent from the CLI.
+# TODO: add a test that publishes a ComponentRun or Component from the CLI.
 # def test_web_registry_from_cli():
 #     from tests.utils import run_test_command
 #     run_test_command()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,6 +14,8 @@ GH_SB3_AGENT_DIR = EXAMPLE_AGENT_DIR / "gh_sb3_agent"
 RLLIB_AGENT_DIR = EXAMPLE_AGENT_DIR / "rllib_agent"
 SB3_AGENT_DIR = EXAMPLE_AGENT_DIR / "sb3_agent"
 
+TESTING_BRANCH_NAME = "test_prod"
+
 
 def run_test_command(cmd, cli_args=None, cli_kwargs=None):
     call_list = [a for a in (cli_args or [])]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,6 +14,7 @@ GH_SB3_AGENT_DIR = EXAMPLE_AGENT_DIR / "gh_sb3_agent"
 RLLIB_AGENT_DIR = EXAMPLE_AGENT_DIR / "rllib_agent"
 SB3_AGENT_DIR = EXAMPLE_AGENT_DIR / "sb3_agent"
 
+TESTING_GITHUB_REPO = "https://github.com/agentos-project/agentos.git"
 TESTING_BRANCH_NAME = "test_prod"
 
 

--- a/web/registry/tests/test_integration.py
+++ b/web/registry/tests/test_integration.py
@@ -86,9 +86,7 @@ class WebRegistryIntegrationTestCases(LiveServerTestCase):
         self.assertEqual(
             flat_comp_spec[full_id]["class_name"], "SimpleComponent",
         )
-        self.assertEqual(
-            comp["SimpleComponent==test_staging"]["repo"], "AgentOSRepo"
-        )
+        self.assertEqual(flat_comp_spec[full_id]["repo"], "AgentOSRepo")
 
         # TODO - FIXME
         # Test adding a ComponentRun

--- a/web/registry/tests/test_integration.py
+++ b/web/registry/tests/test_integration.py
@@ -2,11 +2,12 @@ from django.test import LiveServerTestCase
 from agentos.registry import WebRegistry
 from agentos.component import Component
 from agentos.repo import Repo
+from tests.utils import TESTING_GITHUB_REPO, TESTING_BRANCH_NAME
 
 agentos_repo_spec = {
     "AgentOSRepo": {
         "type": "github",
-        "url": "https://github.com/agentos-project/agentos.git",
+        "url": TESTING_GITHUB_REPO,
     }
 }
 agentos_component_spec = {
@@ -49,7 +50,7 @@ class WebRegistryIntegrationTestCases(LiveServerTestCase):
         self.assertEqual(flat_repo_spec["type"], "github")
         self.assertEqual(
             flat_repo_spec["url"],
-            "https://github.com/agentos-project/agentos.git",
+            TESTING_GITHUB_REPO,
         )
 
         # Test fetching a unflattened (i.e., nested) repo_spec.
@@ -61,7 +62,7 @@ class WebRegistryIntegrationTestCases(LiveServerTestCase):
         # Test adding a component that we generate from the repo.
         simple_component = Component.from_repo(
             repo,
-            identifier="SimpleComponent==test_staging",
+            identifier=f"SimpleComponent=={TESTING_BRANCH_NAME}",
             class_name="SimpleComponent",
             file_path="tests/test_web_registry.py",
         )
@@ -70,20 +71,20 @@ class WebRegistryIntegrationTestCases(LiveServerTestCase):
         web_registry.add_component_spec(simple_component.to_spec())
 
         # Test getting a flattened component (i.e., the one we just added)
-        comp = web_registry.get_component_spec(
-            name="SimpleComponent", version="test_staging", flatten=True
+        flat_comp_spec = web_registry.get_component_spec(
+            name="SimpleComponent", version=TESTING_BRANCH_NAME, flatten=True
         )
-        self.assertEqual(comp["name"], "SimpleComponent")
-        self.assertEqual(comp["version"], "test_staging")
-        self.assertEqual(comp["repo"], "AgentOSRepo")
+        self.assertEqual(flat_comp_spec["name"], "SimpleComponent")
+        self.assertEqual(flat_comp_spec["version"], TESTING_BRANCH_NAME)
+        self.assertEqual(flat_comp_spec["repo"], "AgentOSRepo")
 
         # Test getting an unflattened component (i.e., the one we just added)
-        comp = web_registry.get_component_spec(
-            name="SimpleComponent", version="test_staging", flatten=False
+        flat_comp_spec = web_registry.get_component_spec(
+            name="SimpleComponent", version=TESTING_BRANCH_NAME, flatten=False
         )
+        full_id = f"SimpleComponent=={TESTING_BRANCH_NAME}"
         self.assertEqual(
-            comp["SimpleComponent==test_staging"]["class_name"],
-            "SimpleComponent",
+            flat_comp_spec[full_id]["class_name"], "SimpleComponent",
         )
         self.assertEqual(
             comp["SimpleComponent==test_staging"]["repo"], "AgentOSRepo"


### PR DESCRIPTION
Since some of our tests fetch source code from the agentos-project GitHub repo, it is helpful to be able to have that code depend on a branch that is easy to change in one place.

This will allow PR branches to easily use a `test_staging` branch and then after the PR is approved -- right before it is merged -- we can push update the `test_prod` branch to match the `test_staging` branch and change the code to use the `test_prod` branch.

I don't love the solution, but it seems much better than what we had before which is tests that depend on various static branches that we then have to hunt down an push updates to.