### PR TITLE
Fix broken model saving/loading via mlflow in acme agents (fix #233)

### DIFF
--- a/agentos/agent_run.py
+++ b/agentos/agent_run.py
@@ -194,7 +194,7 @@ class AgentRun(Run):
     def end(
         self,
         status: str = RunStatus.to_string(RunStatus.FINISHED),
-        print_results: bool = False,
+        print_results: bool = True,
     ) -> None:
         super().end(status)
         self.log_run_metrics()

--- a/agentos/run.py
+++ b/agentos/run.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from mlflow.entities import RunStatus
 from mlflow.exceptions import MlflowException
 from mlflow.tracking import MlflowClient
+from mlflow.tracking.context import registry as context_registry
 from agentos.identifiers import RunIdentifier
 from agentos.registry import Registry
 from agentos.specs import RunSpec
@@ -99,6 +100,9 @@ class Run:
             new_run = self._mlflow_client.create_run(exp_id)
             self._mlflow_run_id = new_run.info.run_id
             self.set_tag(self.PCS_RUN_TAG, "True")
+            resolved_tags = context_registry.resolve_tags()
+            for tag_k, tag_v in resolved_tags.items():
+                self.set_tag(tag_k, tag_v)
 
     @classmethod
     def run_exists(cls, run_id) -> bool:

--- a/agentos/utils.py
+++ b/agentos/utils.py
@@ -78,6 +78,7 @@ def _handle_acme_r2d2(version_string):
         "dataset": f"acme_r2d2_dataset=={version_string}",
         "environment": f"acme_cartpole=={version_string}",
         "network": f"acme_r2d2_network=={version_string}",
+        "TFModelSaver": f"TFModelSaver=={version_string}",
         "policy": f"acme_r2d2_policy=={version_string}",
         "AcmeRun": f"AcmeRun=={version_string}",
         "trainer": f"acme_r2d2_trainer=={version_string}",

--- a/example_agents/acme_dqn/agent.py
+++ b/example_agents/acme_dqn/agent.py
@@ -37,4 +37,4 @@ class AcmeDQNAgent:
                 self.environment, self.agent, should_update=True, logger=run
             )
             loop.run(num_episodes=num_episodes)
-            self.network.save()
+            self.network.save(run)

--- a/example_agents/acme_dqn/network.py
+++ b/example_agents/acme_dqn/network.py
@@ -31,7 +31,7 @@ class AcmeDQNNetwork:
         runs = Run.get_all_runs()
         for run in runs:
             try:
-                save_path = run.download_artifacts(self.save_as_name)
+                save_path = Path(run.download_artifacts(self.save_as_name))
                 if save_path.is_dir():
                     checkpoint = tf.train.Checkpoint(module=self.net)
                     latest = tf.train.latest_checkpoint(save_path)
@@ -42,8 +42,8 @@ class AcmeDQNNetwork:
                             f"{self.save_as_name}."
                         )
                         return
-            except:
-                pass
+            except IOError as e:
+                print(f"failed to download artifacts: {e}")
         print(
             f"AcmeRunManager: No saved Tensorflow model "
             f"{self.save_as_name} found."

--- a/example_agents/acme_dqn/network.py
+++ b/example_agents/acme_dqn/network.py
@@ -11,17 +11,23 @@ class TFModelSaver:
     Handles saving and restoring TF models to/from Runs.
     Can be used by different network components.
     """
-    @staticmethod
-    def save(save_as_name: str, network: tf.Module, run=None):
+
+    @classmethod
+    def save(cls, save_as_name: str, network: tf.Module, run=None):
+        print(f"in save, network is {network}.")
         dir_path = Path(tempfile.mkdtemp())
+        print(
+            f"{cls.__name__}: Saving model as "
+            f"{dir_path / save_as_name / save_as_name}"
+        )
         checkpoint = tf.train.Checkpoint(module=network)
         checkpoint.save(dir_path / save_as_name / save_as_name)
         if run:
             run.log_artifact(dir_path / save_as_name)
         shutil.rmtree(dir_path)
 
-    @staticmethod
-    def restore(save_as_name: str, network: tf.Module):
+    @classmethod
+    def restore(cls, save_as_name: str, network: tf.Module):
         runs = Run.get_all_runs()
         for run in runs:
             try:
@@ -32,14 +38,14 @@ class TFModelSaver:
                     if latest is not None:
                         checkpoint.restore(latest)
                         print(
-                            f"AcmeRunManager: Restored Tensorflow model "
-                            f"{save_as_name}."
+                            f"{cls.__name__}: Restored Tensorflow model "
+                            f"{save_as_name} from {save_path}."
                         )
                         return
             except IOError as e:
                 print(f"failed to download artifacts: {e}")
         print(
-            f"AcmeRunManager: No saved Tensorflow model "
+            f"{cls.__name__}: No saved Tensorflow model "
             f"{save_as_name} found."
         )
 

--- a/example_agents/acme_dqn/network.py
+++ b/example_agents/acme_dqn/network.py
@@ -30,19 +30,20 @@ class AcmeDQNNetwork:
     def restore(self):
         runs = Run.get_all_runs()
         for run in runs:
-            save_path = run.download_artifacts(self.save_as_name)
-            if save_path.is_dir():
-                checkpoint = tf.train.Checkpoint(module=self.net)
-                latest = tf.train.latest_checkpoint(save_path)
-                if latest is not None:
-                    checkpoint.restore(latest)
-                    self.save_tensorflow()
-                    print(
-                        f"AcmeRunManager: Restored Tensorflow model "
-                        f"{self.save_as_name}."
-                    )
-                    return
-        self.save_tensorflow()
+            try:
+                save_path = run.download_artifacts(self.save_as_name)
+                if save_path.is_dir():
+                    checkpoint = tf.train.Checkpoint(module=self.net)
+                    latest = tf.train.latest_checkpoint(save_path)
+                    if latest is not None:
+                        checkpoint.restore(latest)
+                        print(
+                            f"AcmeRunManager: Restored Tensorflow model "
+                            f"{self.save_as_name}."
+                        )
+                        return
+            except:
+                pass
         print(
             f"AcmeRunManager: No saved Tensorflow model "
             f"{self.save_as_name} found."

--- a/example_agents/acme_dqn/network.py
+++ b/example_agents/acme_dqn/network.py
@@ -6,6 +6,44 @@ from pathlib import Path
 from agentos.run import Run
 
 
+class TFModelSaver:
+    """
+    Handles saving and restoring TF models to/from Runs.
+    Can be used by different network components.
+    """
+    @staticmethod
+    def save(save_as_name: str, network: tf.Module, run=None):
+        dir_path = Path(tempfile.mkdtemp())
+        checkpoint = tf.train.Checkpoint(module=network)
+        checkpoint.save(dir_path / save_as_name / save_as_name)
+        if run:
+            run.log_artifact(dir_path / save_as_name)
+        shutil.rmtree(dir_path)
+
+    @staticmethod
+    def restore(save_as_name: str, network: tf.Module):
+        runs = Run.get_all_runs()
+        for run in runs:
+            try:
+                save_path = Path(run.download_artifacts(save_as_name))
+                if save_path.is_dir():
+                    checkpoint = tf.train.Checkpoint(module=network)
+                    latest = tf.train.latest_checkpoint(save_path)
+                    if latest is not None:
+                        checkpoint.restore(latest)
+                        print(
+                            f"AcmeRunManager: Restored Tensorflow model "
+                            f"{save_as_name}."
+                        )
+                        return
+            except IOError as e:
+                print(f"failed to download artifacts: {e}")
+        print(
+            f"AcmeRunManager: No saved Tensorflow model "
+            f"{save_as_name} found."
+        )
+
+
 class AcmeDQNNetwork:
     def __init__(self):
         self.net = snt.Sequential(
@@ -20,31 +58,7 @@ class AcmeDQNNetwork:
         self.restore()
 
     def save(self, run=None):
-        dir_path = Path(tempfile.mkdtemp())
-        checkpoint = tf.train.Checkpoint(module=self.net)
-        checkpoint.save(dir_path / self.save_as_name / self.save_as_name)
-        if run:
-            run.log_artifact(dir_path / self.save_as_name)
-        shutil.rmtree(dir_path)
+        TFModelSaver.save(self.save_as_name, self.net, run=run)
 
     def restore(self):
-        runs = Run.get_all_runs()
-        for run in runs:
-            try:
-                save_path = Path(run.download_artifacts(self.save_as_name))
-                if save_path.is_dir():
-                    checkpoint = tf.train.Checkpoint(module=self.net)
-                    latest = tf.train.latest_checkpoint(save_path)
-                    if latest is not None:
-                        checkpoint.restore(latest)
-                        print(
-                            f"AcmeRunManager: Restored Tensorflow model "
-                            f"{self.save_as_name}."
-                        )
-                        return
-            except IOError as e:
-                print(f"failed to download artifacts: {e}")
-        print(
-            f"AcmeRunManager: No saved Tensorflow model "
-            f"{self.save_as_name} found."
-        )
+        TFModelSaver.restore(self.save_as_name, self.net)

--- a/example_agents/acme_dqn/requirements.txt
+++ b/example_agents/acme_dqn/requirements.txt
@@ -27,7 +27,7 @@ distlib==0.3.3
 distro==1.4.0
 dm-acme==0.2.1
 dm-env==1.5
-dm-reverb[tensorflow]
+dm-reverb[tensorflow]==0.6.1
 dm-sonnet==2.0.0
 dm-tree==0.1.6
 docker==5.0.0

--- a/example_agents/acme_dqn/run.py
+++ b/example_agents/acme_dqn/run.py
@@ -4,7 +4,7 @@ import shutil
 import tensorflow as tf
 from pathlib import Path
 from agentos.agent_run import AgentRun
-from agentos.run import Run
+from component_run import active_component_run
 
 
 # Adheres to Acme Logger interface
@@ -21,12 +21,12 @@ class AcmeRun(AgentRun):
     def close(self):
         pass
 
-    @staticmethod
-    def save_tensorflow(name: str, network: tf.Module):
+    @classmethod
+    def save_tensorflow(cls, name: str, network: tf.Module):
         dir_path = Path(tempfile.mkdtemp())
         checkpoint = tf.train.Checkpoint(module=network)
         checkpoint.save(dir_path / name / name)
-        mlflow.log_artifact(dir_path / name)
+        active_component_run(cls).log_artifact(dir_path / name)
         shutil.rmtree(dir_path)
 
     @classmethod

--- a/example_agents/acme_dqn/run.py
+++ b/example_agents/acme_dqn/run.py
@@ -1,10 +1,4 @@
-import mlflow
-import tempfile
-import shutil
-import tensorflow as tf
-from pathlib import Path
 from agentos.agent_run import AgentRun
-from component_run import active_component_run
 
 
 # Adheres to Acme Logger interface
@@ -20,32 +14,3 @@ class AcmeRun(AgentRun):
     # Acme logger API
     def close(self):
         pass
-
-    @classmethod
-    def save_tensorflow(cls, name: str, network: tf.Module):
-        dir_path = Path(tempfile.mkdtemp())
-        checkpoint = tf.train.Checkpoint(module=network)
-        checkpoint.save(dir_path / name / name)
-        active_component_run(cls).log_artifact(dir_path / name)
-        shutil.rmtree(dir_path)
-
-    @classmethod
-    def restore_tensorflow(cls, name: str, network: tf.Module) -> None:
-        runs = Run.get_all_runs()
-        for run in runs:
-            artifacts_uri = run.info.artifact_uri
-            if "file://" != artifacts_uri[:7]:
-                raise Exception(f"Non-local artifacts path: {artifacts_uri}")
-            artifacts_dir = Path(artifacts_uri[7:]).absolute()
-            save_path = artifacts_dir / name
-            if save_path.is_dir():
-
-                checkpoint = tf.train.Checkpoint(module=network)
-                latest = tf.train.latest_checkpoint(save_path)
-                if latest is not None:
-                    checkpoint.restore(latest)
-                    cls.save_tensorflow(name, network)
-                    print(f"AcmeRunManager: Restored Tensorflow model {name}.")
-                    return
-        cls.save_tensorflow(name, network)
-        print(f"AcmeRunManager: No saved Tensorflow model {name} found.")

--- a/example_agents/acme_r2d2/agent.py
+++ b/example_agents/acme_r2d2/agent.py
@@ -27,7 +27,7 @@ class AcmeR2D2Agent:
                 logger=run,
             )
             loop.run(num_episodes=int(num_episodes))
-            self.network.save()
+            self.network.save(run=run)
 
     # Acme agent API
     def observe_first(self, timestep):

--- a/example_agents/acme_r2d2/components.yaml
+++ b/example_agents/acme_r2d2/components.yaml
@@ -38,7 +38,14 @@ components:
         dependencies: 
             environment: environment
             AcmeRun: AcmeRun
-    
+            TFModelSaver: TFModelSaver
+
+    TFModelSaver:
+        repo: local_dir
+        file_path: ../acme_dqn/network.py
+        class_name: TFModelSaver
+        instantiate: False
+
     dataset:
         repo: local_dir
         file_path: ./dataset.py

--- a/example_agents/acme_r2d2/network.py
+++ b/example_agents/acme_r2d2/network.py
@@ -6,11 +6,13 @@ class R2D2Network:
     def __init__(self):
         self.rnn = BasicRNN(self.environment)
 
-    def restore(self):
-        self.AcmeRun.restore_tensorflow("rnn", self.rnn)
+    def save(self, run=None):
+        # This attribute is set up by AgentOS
+        self.TFModelSaver.save("rnn", self.rnn, run=run)
 
-    def save(self):
-        self.AcmeRun.save_tensorflow("rnn", self.rnn)
+    def restore(self):
+        # This attribute is set up by AgentOS
+        self.TFModelSaver.restore("rnn", self.rnn)
 
 
 # BasicRNN, taken from r2d2 test

--- a/example_agents/acme_r2d2/requirements.txt
+++ b/example_agents/acme_r2d2/requirements.txt
@@ -27,7 +27,7 @@ distlib==0.3.3
 distro==1.4.0
 dm-acme==0.2.1
 dm-env==1.5
-dm-reverb[tensorflow]
+dm-reverb[tensorflow]==0.6.1
 dm-sonnet==2.0.0
 dm-tree==0.1.6
 docker==5.0.0


### PR DESCRIPTION
This Fixes #233. Update the dqn (and r2d2) agent to successfully load and save to tensorflow, using MLflow as the mechanism for communication between runs.

This is based onto top of #234