### PR TITLE
Make it easier (and more intuitive?) to use `Component.run()`

### DIFF
--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -175,7 +175,7 @@ def run(
         arg_set = ArgumentSet.from_yaml(param_file)
         entry_point = entry_point or component.get_default_entry_point()
         arg_set.update(component_name, entry_point, param_dict)
-        run = component.run(entry_point, arg_set)
+        run = component.run_with_arg_set(entry_point, arg_set)
         print(f"Run {run.identifier} recorded.", end=" ")
         print("Execute the following for details:")
         print(f"\n  agentos status {run.identifier}\n")

--- a/agentos/component.py
+++ b/agentos/component.py
@@ -278,7 +278,7 @@ class Component:
             entry_point = "run"
         return entry_point
 
-    def new_run(self, entry_point: str, **kwargs):
+    def run(self, entry_point: str, **kwargs):
         """
         Run an entry point with provided parameters. If you need to specify
         arguments to the init function of the managed object or any of

--- a/agentos/component.py
+++ b/agentos/component.py
@@ -278,7 +278,26 @@ class Component:
             entry_point = "run"
         return entry_point
 
-    def run(
+    def new_run(self, entry_point: str, **kwargs):
+        """
+        Run an entry point with provided parameters. If you need to specify
+        arguments to the init function of the managed object or any of
+        its dependency components, use :py:func:run_with_arg_set:.
+
+        :param entry_point: name of function to call on manage object.
+        :param kwargs: keyword-only args to pass through to managed object
+            function called entry-point.
+        :return: the return value of the entry point called.
+        """
+        arg_set = ArgumentSet({self.name: {entry_point: kwargs}})
+        run = self.run_with_arg_set(
+            entry_point,
+            args=arg_set,
+            log_return_value=True,
+        )
+        return run.return_value
+
+    def run_with_arg_set(
         self,
         entry_point: str,
         args: Union[ArgumentSet, Dict] = None,

--- a/agentos/component_run.py
+++ b/agentos/component_run.py
@@ -240,7 +240,9 @@ class ComponentRun(Run):
             with open(filename, "w") as f:
                 yaml.dump(ret_val, f)
         else:
-            raise PythonComponentSystemException("Invalid format provided")
+            raise PythonComponentSystemException(
+                f"Invalid format provided: {format}"
+            )
         self.log_artifact(str(filename))
         filename.unlink()
 

--- a/agentos/registry.py
+++ b/agentos/registry.py
@@ -143,8 +143,10 @@ class Registry(abc.ABC):
             config = yaml.safe_load(file_in)
         return InMemoryRegistry(config, base_dir=str(Path(file_path).parent))
 
-    @staticmethod
-    def from_repo(repo: "Repo", file_path: str, version: str, format: str = "yaml"):
+    @classmethod
+    def from_repo(
+        cls, repo: "Repo", file_path: str, version: str, format: str = "yaml"
+    ) -> "Registry":
         """
         Read in a registry file from an repo.
 
@@ -157,7 +159,7 @@ class Registry(abc.ABC):
         assert format == "yaml", (
             "YAML is the only registry file format supported currently"
         )
-        return Registry.from_yaml(repo.get_local_repo_dir(version) / file_path)
+        return cls.from_yaml(repo.get_local_repo_dir(version) / file_path)
 
     @classmethod
     def from_default(cls):

--- a/agentos/registry.py
+++ b/agentos/registry.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from agentos.component import Component
     from agentos.run import Run
+    from agentos.repo import Repo
 
 # add USE_LOCAL_SERVER=True to .env to talk to local server
 load_dotenv()
@@ -137,10 +138,26 @@ class Registry(abc.ABC):
         return InMemoryRegistry(input_dict)
 
     @staticmethod
-    def from_yaml(yaml_file: str) -> "Registry":
-        with open(yaml_file) as file_in:
+    def from_yaml(file_path: str) -> "Registry":
+        with open(file_path) as file_in:
             config = yaml.safe_load(file_in)
-        return InMemoryRegistry(config, base_dir=str(Path(yaml_file).parent))
+        return InMemoryRegistry(config, base_dir=str(Path(file_path).parent))
+
+    @staticmethod
+    def from_repo(repo: "Repo", file_path: str, version: str, format: str = "yaml"):
+        """
+        Read in a registry file from an repo.
+
+        :param repo: Repo to load registry file from.
+        :param file_path: Path within Repo that registry is located, relative
+            to the repo root.
+        :param format: Optionally specify the format of the registry file.
+        :return: a new Registry object.
+        """
+        assert format == "yaml", (
+            "YAML is the only registry file format supported currently"
+        )
+        return Registry.from_yaml(repo.get_local_repo_dir(version) / file_path)
 
     @classmethod
     def from_default(cls):

--- a/agentos/run_command.py
+++ b/agentos/run_command.py
@@ -189,7 +189,9 @@ class RunCommand:
 
         :return: a new RunCommand object representing the rerun.
         """
-        return self.component.run_with_arg_set(self.entry_point, self.argument_set)
+        return self.component.run_with_arg_set(
+            self.entry_point, self.argument_set
+        )
 
     def to_spec(self, flatten: bool = False) -> RunCommandSpec:
         flat_spec = {

--- a/agentos/run_command.py
+++ b/agentos/run_command.py
@@ -189,7 +189,7 @@ class RunCommand:
 
         :return: a new RunCommand object representing the rerun.
         """
-        return self.component.run(self.entry_point, self.argument_set)
+        return self.component.run_with_arg_set(self.entry_point, self.argument_set)
 
     def to_spec(self, flatten: bool = False) -> RunCommandSpec:
         flat_spec = {

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -67,7 +67,7 @@ def test_component_repl_demo():
     assert class_dep_obj().x == "x_val"
 
     # Instantiate a SimpleAgent and run reset_env() method
-    r = agent_comp.run("reset_env")
+    r = agent_comp.run_with_arg_set("reset_env")
     assert type(r) == ComponentRun
     assert type(r.run_command) == RunCommand
     assert r.run_command.component == agent_comp
@@ -112,7 +112,7 @@ def test_component_from_github_with_venv():
         random_component = Component.from_github_registry(
             random_url, "agent", use_venv=True
         )
-        random_component.run("run_episodes")
+        random_component.run_with_arg_set("run_episodes")
 
 
 def test_component_from_github_no_venv():
@@ -124,4 +124,4 @@ def test_component_from_github_no_venv():
         random_component = Component.from_github_registry(
             sb3_url, "sb3_agent", use_venv=False
         )
-        random_component.run("evaluate")
+        random_component.run_with_arg_set("evaluate")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -69,7 +69,7 @@ def test_registry_integration(venv):
     }
     registry = Registry.from_dict(generate_dummy_dev_registry())
     component = Component.from_registry(registry, "acme_r2d2_agent")
-    component.run("evaluate", ArgumentSet(args))
+    component.run_with_arg_set("evaluate", ArgumentSet(args))
 
 
 def test_registry_from_dict():
@@ -113,7 +113,7 @@ def test_registry_from_file():
     assert (
         random_local_ag.dependencies["environment"].identifier == "environment"
     )
-    random_local_ag.run(
+    random_local_ag.run_with_arg_set(
         "run_episodes",
         ArgumentSet({"agent": {"run_episodes": {"num_episodes": 5}}}),
     )

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -18,7 +18,7 @@ def test_component_run():
         {"Simple": {"__init__": {"x": 1}, "fn": {"input": "hi"}}}
     )
     c = Component.from_class(Simple)
-    run = c.run("fn", arg_set)
+    run = c.run_with_arg_set("fn", arg_set)
     assert run.run_command.component == c
     assert run.run_command.entry_point == "fn"
     new_run = run.run_command.run()

--- a/web/registry/tests/test_integration.py
+++ b/web/registry/tests/test_integration.py
@@ -146,7 +146,9 @@ class WebRegistryIntegrationTestCases(LiveServerTestCase):
 
         # Test adding a RunCommand
         arg_set = {"SimpleComponent": {"add_to_init_member": {"i": 10}}}
-        comp_run = simple_component.run_with_arg_set("add_to_init_member", arg_set)
+        comp_run = simple_component.run_with_arg_set(
+            "add_to_init_member", arg_set
+        )
         run_cmd = comp_run.run_command
         web_registry.add_run_command_spec(run_cmd.to_spec())
 

--- a/web/registry/tests/test_integration.py
+++ b/web/registry/tests/test_integration.py
@@ -41,10 +41,10 @@ class WebRegistryIntegrationTestCases(LiveServerTestCase):
             class_name="SimpleComponent",
             file_path="tests/test_web_registry.py",
         )
-        param_set = {"SimpleComponent": {"add_to_init_member": {"i": 10}}}
+        arg_set = {"SimpleComponent": {"add_to_init_member": {"i": 10}}}
         comp_run = simple_component.run(
             "add_to_init_member",
-            param_set,
+            arg_set,
         )
         self.assertEqual(comp_run.return_value, 11)
         comp_run.to_registry(web_registry)
@@ -145,8 +145,8 @@ class WebRegistryIntegrationTestCases(LiveServerTestCase):
         self.assertEqual(flat_comp_spec[full_id]["repo"], "AgentOSRepo")
 
         # Test adding a RunCommand
-        param_set = {"SimpleComponent": {"add_to_init_member": {"i": 10}}}
-        comp_run = simple_component.run("add_to_init_member", param_set)
+        arg_set = {"SimpleComponent": {"add_to_init_member": {"i": 10}}}
+        comp_run = simple_component.run("add_to_init_member", arg_set)
         run_cmd = comp_run.run_command
         web_registry.add_run_command_spec(run_cmd.to_spec())
 

--- a/web/registry/tests/test_integration.py
+++ b/web/registry/tests/test_integration.py
@@ -42,7 +42,7 @@ class WebRegistryIntegrationTestCases(LiveServerTestCase):
             file_path="tests/test_web_registry.py",
         )
         arg_set = {"SimpleComponent": {"add_to_init_member": {"i": 10}}}
-        comp_run = simple_component.run(
+        comp_run = simple_component.run_with_arg_set(
             "add_to_init_member",
             arg_set,
         )
@@ -146,7 +146,7 @@ class WebRegistryIntegrationTestCases(LiveServerTestCase):
 
         # Test adding a RunCommand
         arg_set = {"SimpleComponent": {"add_to_init_member": {"i": 10}}}
-        comp_run = simple_component.run("add_to_init_member", arg_set)
+        comp_run = simple_component.run_with_arg_set("add_to_init_member", arg_set)
         run_cmd = comp_run.run_command
         web_registry.add_run_command_spec(run_cmd.to_spec())
 

--- a/web/registry/tests/test_registry.py
+++ b/web/registry/tests/test_registry.py
@@ -29,7 +29,7 @@ class RegistryTestCases(TestCase):
         )
         self.run_command = RunCommand.objects.create(
             entry_point="test_entry_pt",
-            parameter_set={},
+            argument_set={},
             component=self.component,
         )
         self.run = Run.objects.create(


### PR DESCRIPTION
NOTE: this is based on #263. Let's merge that first!

We've been talking about making`Component.run()` easier to use by getting rid of the burden of building an `ArgumentSet`. This does that by renaming the existing version of the function (which has lots of knobs and requires an ArgumentSet) to be `Component.run_with_arg_set()` and having the `run()` function itself be simpler and behave more like the entry point function itself, e.g.: you just pass the entry point args directly into the `run()` function and get back the return value.

The trade-off is that you don't get a pointer back to the ComponentRun that was created.

This also adds a convenience function `Registry.from_repo()`.

Demo:

```python
import agentos
repo = agentos.Repo.from_github("agentos-project", "agentos")
reg = agentos.Registry.from_repo(repo, "example_agents/random/components.yaml", "master")
comp = agentos.Component.from_registry(reg, "agent")
comp.run("run_episodes", num_episodes=10000)
```