### PR TITLE
Clean up `Component.from_github_registry()` implementation 

### DIFF
--- a/agentos/component.py
+++ b/agentos/component.py
@@ -100,13 +100,17 @@ class Component:
 
             https://github.com/<project>/<repo>/{blob,raw}/<branch>/<path>
         """
-        repo_url, branch_name, repo_path = parse_github_web_ui_url(github_url)
-        version = version or branch_name
-        registry = Registry.from_github(repo_url, version, repo_path)
+        project, repo, branch, repo_path = parse_github_web_ui_url(github_url)
+        version = version or branch
+        repo = Repo.from_github(project, repo)
+        registry = Registry.from_repo(repo, repo_path, version)
+        c_version = None
+        if registry.has_component_by_name(name=name, version=version):
+            c_version = version
         if use_venv:
-            venv = VirtualEnv.from_registry(registry, name, version)
+            venv = VirtualEnv.from_registry(registry, name, c_version)
             venv.activate()
-        return cls.from_registry(registry, name, version)
+        return Component.from_registry(registry, name, c_version)
 
     @classmethod
     def from_default_registry(

--- a/agentos/repo.py
+++ b/agentos/repo.py
@@ -15,7 +15,7 @@ from agentos.exceptions import (
     BadGitStateException,
     PythonComponentSystemException,
 )
-from agentos.utils import AOS_GLOBAL_REPOS_DIR, parse_github_web_ui_url
+from agentos.utils import AOS_GLOBAL_REPOS_DIR
 from agentos.identifiers import ComponentIdentifier, RepoIdentifier
 from agentos.specs import RepoSpec, NestedRepoSpec, RepoSpecKeys, flatten_spec
 from agentos.registry import Registry, InMemoryRegistry
@@ -275,8 +275,8 @@ class GitHubRepo(Repo):
     def __init__(self, identifier: str, url: str):
         super().__init__(identifier)
         self.type = RepoType.GITHUB
-        if url != self.UNKNOWN_URL:
-            url, _, _ = parse_github_web_ui_url(url)
+        # https repo link allows for cloning without unlocking your GitHub keys
+        url = url.replace("git@github.com:", "https://github.com/")
         self.url = url
         self.local_repo_path = None
         self.porcelain_repo = None

--- a/agentos/utils.py
+++ b/agentos/utils.py
@@ -27,14 +27,16 @@ def parse_github_web_ui_url(
     This will replace an SSH URL (i.e. one that starts with
     ``git@github.com:``) into a URL that starts with ``https://github.com/``.
 
-    This returns a 3-tuple of:
+    This returns a 4-tuple of:
 
-    1. The repo URL (i.e. the https URL the repo can be cloned from)
+    1. The GitHub project name
 
-    2. The branch_name or commit hash contained in the URL (``None`` if URL is
+    2. The GitHub repo name
+
+    3. The branch_name or commit hash contained in the URL (``None`` if URL is
        of the project root form)
 
-    3. The path of the file contained in the suffix of the URL (``None`` if
+    4. The path of the file contained in the suffix of the URL (``None`` if
        URL is of the project root form)
     """
     URL_STARTS_WITH = "https://github.com"
@@ -47,18 +49,17 @@ def parse_github_web_ui_url(
     assert len(split_url) >= 2, f" No project or repo in url: {github_url}"
     project_name = split_url[0]
     repo_name = split_url[1]
-    repo_url = "/".join((URL_STARTS_WITH, project_name, repo_name))
 
     # Check if URL is just a link to a GitHub project root
     if len(split_url) == 2:
-        return repo_url, None, None
+        return project_name, repo_name, None, None
 
     # If split is not *just* a project root, then it should look like
     # [<project>, <repo>, {blob/raw}, <branch>, <path_1>, <path_2>, ...]
     assert len(split_url) >= 5, f"Can't find required paths in: {github_url}"
     branch_name = split_url[3]
     repo_path = "/".join(split_url[4:])
-    return repo_url, branch_name, repo_path
+    return project_name, repo_name, branch_name, repo_path
 
 
 def generate_dummy_dev_registry(


### PR DESCRIPTION
Based on your work in #264 , this PR backs out the hacky `Repo` manipulation stuff I was doing in #260 and creates a function that basically wraps your demo from #264 into a single function call.

Same (well, slightly updated) demos from #260:

```python
from agentos import Component
component = Component.from_github_registry("https://github.com/agentos-project/agentos/blob/master/example_agents/sb3_agent/components.yaml", "sb3_agent")
component.run('evaluate')
```

```python
from agentos import Component
from agentos import ArgumentSet
import yaml
import requests
component = Component.from_github_registry("https://github.com/agentos-project/agentos/blob/master/example_agents/acme_r2d2/components.yaml", "agent")
arg_set = ArgumentSet(yaml.safe_load(requests.get('https://github.com/agentos-project/agentos/raw/master/example_agents/acme_r2d2/parameters.yaml').content))
component.run_with_arg_set('evaluate', arg_set)
```

Not sure why my original implementation was so roundabout; will think on it. :P