### PR TITLE
Import and instantiate Components in get_object()

### DIFF
--- a/agentos/component.py
+++ b/agentos/component.py
@@ -39,7 +39,6 @@ class Component:
 
     def __init__(
         self,
-        managed_cls: Type[T],
         repo: Repo,
         identifier: "Component.Identifier",
         class_name: str,
@@ -63,7 +62,6 @@ class Component:
         :param dunder_name: Name used for the pointer to this Component on any
             instances of ``managed_cls`` created by this Component.
         """
-        self._managed_cls = managed_cls
         self.repo = repo
         self.identifier = identifier
         self.class_name = class_name
@@ -231,7 +229,6 @@ class Component:
                 f"file {src_file}."
             )
         return cls(
-            managed_cls=managed_cls,
             repo=repo,
             identifier=Component.Identifier(name),
             class_name=managed_cls.__name__,
@@ -255,16 +252,7 @@ class Component:
         identifier = ComponentIdentifier.from_str(str(identifier))
         full_path = repo.get_local_file_path(identifier.version, file_path)
         assert full_path.is_file(), f"{full_path} does not exist"
-        sys.path.append(str(full_path.parent))
-        spec = importlib.util.spec_from_file_location(
-            f"AOS_MODULE_{class_name.upper()}", str(full_path)
-        )
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        managed_cls = getattr(module, class_name)
-        sys.path.pop()
         return cls(
-            managed_cls=managed_cls,
             repo=repo,
             identifier=identifier,
             class_name=class_name,
@@ -284,7 +272,8 @@ class Component:
 
     def get_default_entry_point(self):
         try:
-            entry_point = self._managed_cls.DEFAULT_ENTRY_POINT
+            imported_obj = self._import_object()
+            entry_point = imported_obj.DEFAULT_ENTRY_POINT
         except AttributeError:
             entry_point = "run"
         return entry_point
@@ -391,13 +380,14 @@ class Component:
     def _get_object(self, arg_set: ArgumentSet, collected: dict) -> T:
         if self.name in collected:
             return collected[self.name]
+        imported_obj = self._import_object()
         if self.instantiate:
-            save_init = self._managed_cls.__init__
-            self._managed_cls.__init__ = lambda self: None
-            obj = self._managed_cls()
+            save_init = imported_obj.__init__
+            imported_obj.__init__ = lambda self: None
+            obj = imported_obj()
         else:
-            print(f"getting {self._managed_cls} w/o instantiating ")
-            obj = self._managed_cls
+            print(f"getting {imported_obj} w/o instantiating ")
+            obj = imported_obj
         for dep_attr_name, dep_component in self.dependencies.items():
             print(f"Adding {dep_attr_name} to {self.name}")
             dep_obj = dep_component._get_object(
@@ -406,10 +396,25 @@ class Component:
             setattr(obj, dep_attr_name, dep_obj)
         setattr(obj, self._dunder_name, self)
         if self.instantiate:
-            self._managed_cls.__init__ = save_init
+            imported_obj.__init__ = save_init
             self.call_function_with_arg_set(obj, "__init__", arg_set)
         collected[self.name] = obj
         return obj
+
+    def _import_object(self):
+        full_path = self.repo.get_local_file_path(
+            self.identifier.version, self.file_path
+        )
+        assert full_path.is_file(), f"{full_path} does not exist"
+        sys.path.append(str(full_path.parent))
+        spec = importlib.util.spec_from_file_location(
+            f"AOS_MODULE_{self.class_name.upper()}", str(full_path)
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        managed_obj = getattr(module, self.class_name)
+        sys.path.pop()
+        return managed_obj
 
     def _handle_repo_spec(self, repos):
         existing_repo = repos.get(self.repo.name)
@@ -435,7 +440,6 @@ class Component:
                 new_identifier, self.requirements_path
             )
         clone = Component(
-            managed_cls=self._managed_cls,
             repo=GitHubRepo(identifier=self.repo.identifier, url=repo_url),
             identifier=new_identifier,
             class_name=self.class_name,

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -43,7 +43,9 @@ def test_component_repl_demo():
         GenericDependency, instantiate=False
     )
     class_comp_with_diff_name = Component.from_class(
-        GenericDependency, identifier="ClassDependency", instantiate=False,
+        GenericDependency,
+        identifier="ClassDependency",
+        instantiate=False,
     )
 
     # Add dependencies to SimpleAgent
@@ -55,7 +57,7 @@ def test_component_repl_demo():
 
     assert "GenericDependency" in agent_comp.dependencies.keys()
     inst_dep_obj = agent_comp.dependencies["GenericDependency"].get_object()
-    assert type(inst_dep_obj) == GenericDependency
+    assert inst_dep_obj.__class__.__name__ == "GenericDependency"
     assert inst_dep_obj.class_member == "class_member_val"
     assert inst_dep_obj.x == "x_val"
 


### PR DESCRIPTION
Fixes #276; moves Component import and instantiation in `get_object()`.  Clears the way for work on #280 .