### PR TITLE
Integrate VirtualEnv management into Component

### DIFF
--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -167,18 +167,16 @@ def run(
     arg_set_file,
     use_venv,
 ):
-    venv = VirtualEnv.from_registry_file(registry_file, component_name)
-    venv.set_environment_handling(use_venv)
-    with venv:
-        cli_arg_dict = _user_args_to_dict(arg_set_list)
-        component = Component.from_registry_file(registry_file, component_name)
-        arg_set = ArgumentSet.from_yaml(arg_set_file)
-        entry_point = entry_point or component.get_default_entry_point()
-        arg_set.update(component_name, entry_point, cli_arg_dict)
-        run = component.run_with_arg_set(entry_point, arg_set)
-        print(f"Run {run.identifier} recorded.", end=" ")
-        print("Execute the following for details:")
-        print(f"\n  agentos status {run.identifier}\n")
+    cli_arg_dict = _user_args_to_dict(arg_set_list)
+    component = Component.from_registry_file(registry_file, component_name)
+    component.set_environment_handling(use_venv)
+    arg_set = ArgumentSet.from_yaml(arg_set_file)
+    entry_point = entry_point or component.get_default_entry_point()
+    arg_set.update(component_name, entry_point, cli_arg_dict)
+    run = component.run_with_arg_set(entry_point, arg_set)
+    print(f"Run {run.identifier} recorded.", end=" ")
+    print("Execute the following for details:")
+    print(f"\n  agentos status {run.identifier}\n")
 
 
 @agentos_cmd.command()
@@ -196,11 +194,9 @@ def status(entity_id, registry_file, use_venv):
         Run.from_existing_run_id(entity_id).print_status(detailed=True)
     else:  # assume entity_id is a ComponentIdentifier
         try:
-            venv = VirtualEnv.from_registry_file(registry_file, entity_id)
-            venv.set_environment_handling(use_venv)
-            with venv:
-                c = Component.from_registry_file(registry_file, entity_id)
-                c.print_status_tree()
+            c = Component.from_registry_file(registry_file, entity_id)
+            c.set_environment_handling(use_venv)
+            c.print_status_tree()
         except LookupError:
             print(f"No Run or component found with Identifier {entity_id}.")
 
@@ -236,12 +232,10 @@ def freeze(component_name, registry_file, force, use_venv):
           the same commit
         * There are no uncommitted changes in the local repo
     """
-    venv = VirtualEnv.from_registry_file(registry_file, component_name)
-    venv.set_environment_handling(use_venv)
-    with venv:
-        component = Component.from_registry_file(registry_file, component_name)
-        frozen_reg = component.to_frozen_registry(force=force)
-        print(yaml.dump(frozen_reg.to_dict()))
+    component = Component.from_registry_file(registry_file, component_name)
+    component.set_environment_handling(use_venv)
+    frozen_reg = component.to_frozen_registry(force=force)
+    print(yaml.dump(frozen_reg.to_dict()))
 
 
 @agentos_cmd.command()
@@ -257,12 +251,10 @@ def publish(
     sub-Components) to the AgentOS server.  This command will fail if any
     Component in the dependency tree cannot be frozen.
     """
-    venv = VirtualEnv.from_registry_file(registry_file, component_name)
-    venv.set_environment_handling(use_venv)
-    with venv:
-        component = Component.from_registry_file(registry_file, component_name)
-        frozen_spec = component.to_frozen_registry(force=force).to_spec()
-        Registry.get_default().add_component_spec(frozen_spec)
+    component = Component.from_registry_file(registry_file, component_name)
+    component.set_environment_handling(use_venv)
+    frozen_spec = component.to_frozen_registry(force=force).to_spec()
+    Registry.get_default().add_component_spec(frozen_spec)
 
 
 @agentos_cmd.command()

--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -168,8 +168,9 @@ def run(
     use_venv,
 ):
     cli_arg_dict = _user_args_to_dict(arg_set_list)
-    component = Component.from_registry_file(registry_file, component_name)
-    component.set_environment_handling(use_venv)
+    component = Component.from_registry_file(
+        registry_file, component_name, use_venv=use_venv
+    )
     arg_set = ArgumentSet.from_yaml(arg_set_file)
     entry_point = entry_point or component.get_default_entry_point()
     arg_set.update(component_name, entry_point, cli_arg_dict)
@@ -194,8 +195,9 @@ def status(entity_id, registry_file, use_venv):
         Run.from_existing_run_id(entity_id).print_status(detailed=True)
     else:  # assume entity_id is a ComponentIdentifier
         try:
-            c = Component.from_registry_file(registry_file, entity_id)
-            c.set_environment_handling(use_venv)
+            c = Component.from_registry_file(
+                registry_file, entity_id, use_venv=use_venv
+            )
             c.print_status_tree()
         except LookupError:
             print(f"No Run or component found with Identifier {entity_id}.")
@@ -232,8 +234,9 @@ def freeze(component_name, registry_file, force, use_venv):
           the same commit
         * There are no uncommitted changes in the local repo
     """
-    component = Component.from_registry_file(registry_file, component_name)
-    component.set_environment_handling(use_venv)
+    component = Component.from_registry_file(
+        registry_file, component_name, use_venv=use_venv
+    )
     frozen_reg = component.to_frozen_registry(force=force)
     print(yaml.dump(frozen_reg.to_dict()))
 
@@ -251,8 +254,9 @@ def publish(
     sub-Components) to the AgentOS server.  This command will fail if any
     Component in the dependency tree cannot be frozen.
     """
-    component = Component.from_registry_file(registry_file, component_name)
-    component.set_environment_handling(use_venv)
+    component = Component.from_registry_file(
+        registry_file, component_name, use_venv=use_venv
+    )
     frozen_spec = component.to_frozen_registry(force=force).to_spec()
     Registry.get_default().add_component_spec(frozen_spec)
 

--- a/agentos/virtual_env.py
+++ b/agentos/virtual_env.py
@@ -19,8 +19,7 @@ class VirtualEnv:
     such as one to clear the whole virtual environment cache.
     """
 
-    def __init__(self, use_venv: bool = True, venv_path: Path = None):
-        self.use_venv = use_venv
+    def __init__(self, venv_path: Path = None):
         self.venv_path = venv_path
         self._saved_venv_sys_path = None
         self._venv_is_active = False
@@ -56,13 +55,6 @@ class VirtualEnv:
             print("VirtualEnv: no requirement paths; Running in an empty env!")
         venv._build_virtual_env(req_paths)
         return venv
-
-    def set_environment_handling(self, use_venv: bool) -> None:
-        """
-        Enables or disables virtual environment management.  If ``use_venv`` is
-        set to False, all public methods of this class will be no-ops.
-        """
-        self.use_venv = use_venv
 
     def set_env_cache_path(self, env_cache_path: Path) -> None:
         """
@@ -108,9 +100,7 @@ class VirtualEnv:
         activated, an import statement (e.g. run by a Component) will execute
         within the virtual environment.
         """
-        if not self.venv_path or not self.use_venv:
-            print("VirtualEnv: Running in outer Python environment")
-            return
+        assert self.venv_path.exists(), f"{self.venv_path} does not exist!"
         self._save_default_env_info()
         self._set_venv_sys_path()
         self._set_venv_sys_attributes()
@@ -297,6 +287,34 @@ class VirtualEnv:
             if found_flags:
                 flag_lines.append(line)
         return flag_dict
+
+
+class NoOpVirtualEnv(VirtualEnv):
+    """
+    This class implements the VirtualEnv interface, but does not actually
+    modify the Python environment in which the program is executing.  Use this
+    class anywhere you need a VirtualEnv object but where you also do not want
+    to modify the execution environment (i.e. you just want to run code in the
+    existing Python environment).
+    """
+
+    @classmethod
+    def from_requirements_paths(cls, req_paths: Sequence) -> "VirtualEnv":
+        return cls()
+
+    def activate(self) -> None:
+        print("VirtualEnv: Running in outer Python environment")
+
+    def deactivate(self) -> None:
+        pass
+
+    def create_virtual_env(self) -> None:
+        pass
+
+    def install_requirements_file(
+        self, req_path: Path, pip_flags: dict = None
+    ) -> None:
+        pass
 
 
 @contextmanager

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -69,6 +69,7 @@ def test_registry_integration(venv):
     }
     registry = Registry.from_dict(generate_dummy_dev_registry())
     component = Component.from_registry(registry, "acme_r2d2_agent")
+    component.set_environment_handling(use_venv=False)
     component.run_with_arg_set("evaluate", ArgumentSet(args))
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -68,8 +68,9 @@ def test_registry_integration(venv):
         },
     }
     registry = Registry.from_dict(generate_dummy_dev_registry())
-    component = Component.from_registry(registry, "acme_r2d2_agent")
-    component.set_environment_handling(use_venv=False)
+    component = Component.from_registry(
+        registry, "acme_r2d2_agent", use_venv=False
+    )
     component.run_with_arg_set("evaluate", ArgumentSet(args))
 
 


### PR DESCRIPTION
As the title says, this PR moves venv management into the Component.  It also cleans up the VirtualEnv API a little bit (~~will create an additional issue for further improvements~~ see #297): 

The following demo now works (note, no manual venv management required).  First in bash, create a new empty Python environment to run the demo script and install agentos:

```bash
virtualenv -p /usr/bin/python3.9 test_env
source test_env/bin/activate
pip install -e .
```

Now try to manually build and run the sb3_agent in the Python REPL:

```python
from agentos import Repo, Component

aos_repo = Repo.from_github("agentos-project", "agentos")

sb3_agent = Component.from_repo(repo=aos_repo, identifier="sb3_agent==master", class_name="SB3PPOAgent", file_path="example_agents/sb3_agent/agent.py", requirements_path="example_agents/sb3_agent/requirements.txt")
env = Component.from_repo(repo=aos_repo, identifier="environment==master", class_name="CartPole", file_path="example_agents/sb3_agent/environment.py")
run = Component.from_repo(repo=aos_repo, identifier="SB3AgentRun==master", class_name="SB3Run", file_path="example_agents/sb3_agent/sb3_run.py", instantiate=False)

sb3_agent.add_dependency(env, attribute_name="environment")
sb3_agent.add_dependency(run, attribute_name="SB3AgentRun")
sb3_agent.run("evaluate")
```




Fixes #280.