### PR TITLE
VirtualEnv can be created from setup.py files

### DIFF
--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -12,6 +12,7 @@ import yaml
 
 from agentos import ArgumentSet, Component
 from agentos.registry import Registry
+from agentos.repo import Repo
 from agentos.run import Run
 from agentos.virtual_env import VirtualEnv
 
@@ -265,7 +266,35 @@ def publish(
 @agentos_cmd.command()
 @_option_assume_yes
 def clear_env_cache(assume_yes):
+    """
+    This command clears all virtual environments that have been cached by
+    AgentOS in your local file system.  All the virtual environments can be
+    automatically recreated when re-running a Component ``requirements_path``
+    specified.
+    """
     VirtualEnv.clear_env_cache(assume_yes=assume_yes)
+
+
+@agentos_cmd.command()
+@_option_assume_yes
+def clear_repo_cache(assume_yes):
+    """
+    This command clears all git repos that have been cached by AgentOS on your
+    local file system.  These repos will be recreated if as you run Components
+    that require them.
+    """
+    Repo.clear_repo_cache(assume_yes=assume_yes)
+
+
+@agentos_cmd.command()
+@_option_assume_yes
+def clear_cache(assume_yes):
+    """
+    This command clears all virtual environments AND git repos that have been
+    cached by AgentOS on your local file system.
+    """
+    VirtualEnv.clear_env_cache(assume_yes=assume_yes)
+    Repo.clear_repo_cache(assume_yes=assume_yes)
 
 
 # Copied from https://github.com/mlflow/mlflow/blob/3958cdf9664ade34ebcf5960bee215c80efae992/mlflow/cli.py#L188 # noqa: E501

--- a/agentos/component.py
+++ b/agentos/component.py
@@ -440,10 +440,11 @@ class Component:
         for c in self.dependency_list(include_parents=True):
             if c.requirements_path is None:
                 continue
-            full_req_path = self.repo.get_local_file_path(
-                c.identifier.version, c.requirements_path
-            ).absolute()
-            req_paths.add(full_req_path)
+            for req_path in c.requirements_path.split(";"):
+                full_req_path = self.repo.get_local_file_path(
+                    c.identifier.version, req_path
+                ).absolute()
+                req_paths.add(full_req_path)
         return VirtualEnv.from_requirements_paths(req_paths)
 
     def _handle_repo_spec(self, repos):

--- a/agentos/utils.py
+++ b/agentos/utils.py
@@ -1,4 +1,5 @@
 import pprint
+import shutil
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -58,6 +59,25 @@ def parse_github_web_ui_url(
     branch_name = split_url[3]
     repo_path = "/".join(split_url[4:])
     return project_name, repo_name, branch_name, repo_path
+
+
+def _clear_cache_path(cache_path: Path, assume_yes: bool):
+    cache_path = Path(cache_path).absolute()
+    if not cache_path.exists():
+        print(f"Cache path {cache_path} does not exist.  Aborting...")
+        return
+    answer = None
+    if assume_yes:
+        answer = "y"
+    else:
+        answer = input(
+            f"This will remove everything under {cache_path}. Continue? [Y/N] "
+        )
+    if assume_yes or answer.lower() in ["y", "yes"]:
+        shutil.rmtree(cache_path)
+        print("Cache cleared...")
+        return
+    print("Aborting...")
 
 
 def generate_dummy_dev_registry(

--- a/example_agents/rllib_agent/requirements.txt
+++ b/example_agents/rllib_agent/requirements.txt
@@ -1,11 +1,13 @@
-# When updating here, also update conda_env.yaml
-requests==2.21.0  # Needed till https://github.com/ray-project/ray/issues/8373 fixed.
-
 # See https://pytorch.org/get-started/locally/ for the command to install
 # the CPU-only torch for each platform.
 # Pass the following option to pip on linux to get the CPU only torch
-# -f https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.1+cpu; sys_platform == 'linux'
-torch==1.9.1; sys_platform == 'windows'
-torch==1.9.1; sys_platform == 'darwin'
-ray[rllib]==1.7.0
+# -f https://download.pytorch.org/whl/cpu/torch_stable.html
+torch==1.10.2+cpu; sys_platform == 'linux'
+torch==1.10.2; sys_platform == 'windows'
+torch==1.10.2; sys_platform == 'darwin'
+ray[rllib]==1.10.0
+gym==0.21.0
+
+# agentos_pip_cmdline:
+#   linux:
+#       "-f": "https://download.pytorch.org/whl/cpu/torch_stable.html"

--- a/example_agents/sb3_agent/requirements.txt
+++ b/example_agents/sb3_agent/requirements.txt
@@ -1,6 +1,6 @@
 # agentos_pip_cmdline:
 #   linux:
-#       "-f": "https://download.pytorch.org/whl/torch_stable.html"
+#       "-f": "https://download.pytorch.org/whl/cpu/torch_stable.html"
 
 stable_baselines3==1.4.0
 dm-env==1.5

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -11,28 +11,27 @@ ACME_DQN_REQS_PATH = EXAMPLE_AGENT_PATH / "acme_dqn" / "requirements.txt"
 ACME_R2D2_REQS_PATH = EXAMPLE_AGENT_PATH / "acme_r2d2" / "requirements.txt"
 WEB_REQS_PATH = REPO_ROOT / "web" / "requirements.txt"
 
+PYTORCH_CPU_URL = "https://download.pytorch.org/whl/cpu/torch_stable.html"
+
 
 def install_with_pip(pip):  # install with given pip
-    subprocess.run([pip, "install", "-r", DEV_REQS_PATH])
+    _run([pip, "install", "-r", DEV_REQS_PATH])
     if sys.platform == "linux":
         # Get CPU-only version of torch in case CUDA is not proper configured
-        subprocess.run(
-            [
-                pip,
-                "install",
-                "-r",
-                RLLIB_REQS_PATH,
-                "-f",
-                "https://download.pytorch.org/whl/torch_stable.html",
-            ]
-        )
-        subprocess.run([pip, "install", "-r", ACME_DQN_REQS_PATH])
-        subprocess.run([pip, "install", "-r", ACME_R2D2_REQS_PATH])
+        _run([pip, "install", "-r", RLLIB_REQS_PATH, "-f", PYTORCH_CPU_URL])
+        _run([pip, "install", "-r", SB3_REQS_PATH, "-f", PYTORCH_CPU_URL])
+        _run([pip, "install", "-r", ACME_DQN_REQS_PATH])
+        _run([pip, "install", "-r", ACME_R2D2_REQS_PATH])
     else:
-        subprocess.run([pip, "install", "-r", RLLIB_REQS_PATH])
-    subprocess.run([pip, "install", "-r", SB3_REQS_PATH])
-    subprocess.run([pip, "install", "-r", WEB_REQS_PATH])
-    subprocess.run([pip, "install", "-e", REPO_ROOT])
+        _run([pip, "install", "-r", RLLIB_REQS_PATH])
+        _run([pip, "install", "-r", SB3_REQS_PATH])
+    _run([pip, "install", "-r", WEB_REQS_PATH])
+    _run([pip, "install", "-e", REPO_ROOT])
+
+
+def _run(cmd):
+    print(f"\n==========\nRUNNING:\n\t{cmd }\n==========\n")
+    subprocess.run(cmd)
 
 
 def install_requirements():

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         "click>=7.0",
-        "gym==0.17.1",
-        "numpy>=1.18.5",
-        "dm-env>=1.5",
         "pyyaml>=5.4.1",
         "mlflow>=1.20.2",
         "dulwich==0.20.28",

--- a/tests/test_agents/setup_py_agent/agent.py
+++ b/tests/test_agents/setup_py_agent/agent.py
@@ -1,0 +1,11 @@
+import arrow  # noqa: F401
+
+
+# A basic agent.
+class BasicAgent:
+    DEFAULT_ENTRY_POINT = "evaluate"
+
+    def evaluate(self):
+        import bottle  # noqa: F401
+
+        print("Successful venv test")

--- a/tests/test_agents/setup_py_agent/setup.py
+++ b/tests/test_agents/setup_py_agent/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup
+
+setup(
+    name="setup_py_agent",
+    description=(
+        "An agent with requirements in setup.py for AOS testing purposes"
+    ),
+    version="1.0.0",
+    install_requires=[
+        "arrow",
+        "bottle",
+    ],
+    license="Apache License 2.0",
+    python_requires=">=3.5",
+    url="https://agentos.org",
+    project_urls={
+        "Source Code": "https://github.com/agentos-project/agentos",
+    },
+)


### PR DESCRIPTION
This PR  allows virtual environments to be created based on the `install_requires` kwarg found in `setup.py` files.  Also included in this PR:

* More cache-clearing commands:
    * `agentos clear-env-cache`
    * `agentos clear-repo-cache`
    * `agentos clear-cache  # clears both env and repo cache`

* You can list multiple requirements files (Python package `setup.py` files or pip-compatible `requirements.txt` files) in the `requirements_path` Component spec key separated by a semicolon and all will be installed into the virtual env.
* Update to `rllib_agent` and `sb3_agent` requirements.
* Minor improvements to the `install_requirements.py` environment setup script.
* Remove unneeded requirements from AgentOS `setup.py`.

Try the following demo in your Python REPL to get a Policy class component out of Ilya's repo:

```python
from agentos import Component, Repo
ilya_repo = Repo.from_github("ikostrikov", "pytorch-a2c-ppo-acktr-gail")
ilya_policy = Component.from_repo( repo=ilya_repo, identifier="Policy==41332b78dfb50321c29bade65f9d244387f68a60", class_name="Policy", file_path="./a2c_ppo_acktr/model.py", requirements_path="./setup.py", instantiate=False)
policy_obj = ilya_policy.get_object()
```

Fixes #275.