### PR TITLE
RunCommand now tracks log_return_value

### DIFF
--- a/agentos/component.py
+++ b/agentos/component.py
@@ -371,7 +371,7 @@ class Component:
                 args = ArgumentSet(args)
         else:
             args = ArgumentSet()
-        run_command = RunCommand(self, entry_point, args)
+        run_command = RunCommand(self, entry_point, args, log_return_value)
         with ComponentRun.from_run_command(run_command) as run:
             for c in self.dependency_list():
                 c.active_run = run
@@ -453,7 +453,7 @@ class Component:
         )
         managed_obj = importlib.util.module_from_spec(spec)
         with self._build_virtual_env():
-            sys.path.append(str(full_path.parent))
+            sys.path.insert(0, str(full_path.parent))
             spec.loader.exec_module(managed_obj)
         if self.class_name:
             managed_obj = getattr(managed_obj, self.class_name)

--- a/agentos/run_command.py
+++ b/agentos/run_command.py
@@ -44,10 +44,12 @@ class RunCommand:
         component: "Component",
         entry_point: str,
         argument_set: "ArgumentSet",
+        log_return_value: bool,
     ):
         self._component = component
         self._entry_point = entry_point
         self._argument_set = argument_set
+        self._log_return_value = log_return_value
 
     def __repr__(self) -> str:
         return f"<agentos.run_command.RunCommand: {self}>"
@@ -62,6 +64,7 @@ class RunCommand:
             self._component.identifier
             + self._entry_point
             + self._argument_set.identifier
+            + str(self._log_return_value)
         )
         return sha1(hash_str.encode("utf-8")).hexdigest()
 
@@ -90,8 +93,9 @@ class RunCommand:
     def argument_set(self):
         return self._argument_set
 
-    def new_run(self, experiment_id: str = None):
-        return Run.from_run_command(self, experiment_id=experiment_id)
+    @property
+    def log_return_value(self):
+        return self._log_return_value
 
     @classmethod
     def from_default_registry(cls, run_id: RunIdentifier) -> "RunCommand":
@@ -121,12 +125,13 @@ class RunCommand:
 
         component = Component.from_registry(registry, component_id)
         arg_set = ArgumentSet.from_spec(
-            inner_spec[RunCommandSpecKeys.PARAMETER_SET]
+            inner_spec[RunCommandSpecKeys.ARGUMENT_SET]
         )
         new_run_cmd = cls(
             component=component,
             entry_point=inner_spec[RunCommandSpecKeys.ENTRY_POINT],
             argument_set=arg_set,
+            log_return_value=inner_spec[RunCommandSpecKeys.LOG_RETURN_VALUE],
         )
         assert new_run_cmd.identifier == spec_identifier, (
             f"Identifier of new run_command {new_run_cmd.identifier} "
@@ -191,7 +196,9 @@ class RunCommand:
         :return: a new RunCommand object representing the rerun.
         """
         return self.component.run_with_arg_set(
-            self.entry_point, self.argument_set
+            self.entry_point,
+            args=self.argument_set,
+            log_return_value=self.log_return_value
         )
 
     def to_spec(self, flatten: bool = False) -> RunCommandSpec:
@@ -199,6 +206,8 @@ class RunCommand:
             RunCommandSpecKeys.IDENTIFIER: self.identifier,
             RunCommandSpecKeys.COMPONENT_ID: str(self._component.identifier),
             RunCommandSpecKeys.ENTRY_POINT: self._entry_point,
-            RunCommandSpecKeys.PARAMETER_SET: self._argument_set.to_spec(),
+            RunCommandSpecKeys.ARGUMENT_SET: self._argument_set.to_spec(),
+            RunCommandSpecKeys.LOG_RETURN_VALUE: self._log_return_value,
+
         }
         return flat_spec if flatten else unflatten_spec(flat_spec)

--- a/agentos/specs.py
+++ b/agentos/specs.py
@@ -80,7 +80,8 @@ class RunCommandSpecKeys:
     IDENTIFIER = "identifier"  # for flattened RunCommandSpec
     COMPONENT_ID = "component"
     ENTRY_POINT = "entry_point"
-    PARAMETER_SET = "argument_set"
+    ARGUMENT_SET = "argument_set"
+    LOG_RETURN_VALUE = "log_return_value"
 
 
 RunSpec = Mapping


### PR DESCRIPTION
Also, add `LOG_RETURN_VALUE` to `RunCommandSpecKeys`
This also renames `RunCommandSpecKeys.PARAMETER_SET` to `ARGUMENT_SET` which we missed in past renaming effort.