### PR TITLE
Only activate a Component's venv once

### DIFF
--- a/tests/test_venv_management.py
+++ b/tests/test_venv_management.py
@@ -5,10 +5,10 @@ import pytest
 
 from agentos.cli import run
 from agentos.component import Component
-from agentos.repo import Repo
+from agentos.repo import LocalRepo, Repo
 from agentos.specs import RepoSpecKeys
-from agentos.virtual_env import VirtualEnv
-from tests.utils import TEST_VENV_AGENT_DIR, run_test_command
+from agentos.virtual_env import VirtualEnv, auto_revert_venv
+from tests.utils import RANDOM_AGENT_DIR, TEST_VENV_AGENT_DIR, run_test_command
 
 
 def _clean_up_sys_modules():
@@ -29,82 +29,133 @@ def _confirm_modules_not_in_env():
 
 
 def test_venv_management(tmpdir):
-    _clean_up_sys_modules()
-    _confirm_modules_not_in_env()
-    tmp_path = Path(tmpdir)
-    env_cache_path = tmp_path / "test_requirements"
-    env_cache_path.mkdir(parents=True, exist_ok=True)
+    with auto_revert_venv():
+        _clean_up_sys_modules()
+        _confirm_modules_not_in_env()
+        tmp_path = Path(tmpdir)
+        env_cache_path = tmp_path / "test_requirements"
+        env_cache_path.mkdir(parents=True, exist_ok=True)
 
-    # Test cache clearing
-    touch_test = env_cache_path / "test_file.out"
-    touch_test.touch()
-    assert touch_test.exists()
-    VirtualEnv.clear_env_cache(env_cache_path=env_cache_path, assume_yes=True)
-    Repo.clear_repo_cache(repo_cache_path=env_cache_path, assume_yes=True)
-    assert not touch_test.exists()
-
-    # Should fail because of --no_venv
-    no_venv_test_args = ["test_venv_agent", "--use-outer-env"]
-    test_kwargs = {
-        "--registry-file": str(TEST_VENV_AGENT_DIR / "components.yaml")
-    }
-    with pytest.raises(ModuleNotFoundError):
-        run_test_command(
-            cmd=run, cli_args=no_venv_test_args, cli_kwargs=test_kwargs
+        # Test cache clearing
+        touch_test = env_cache_path / "test_file.out"
+        touch_test.touch()
+        assert touch_test.exists()
+        VirtualEnv.clear_env_cache(
+            env_cache_path=env_cache_path, assume_yes=True
         )
+        Repo.clear_repo_cache(repo_cache_path=env_cache_path, assume_yes=True)
+        assert not touch_test.exists()
 
-    # Should succeed because we will create a venv
-    venv_test_args = ["test_venv_agent"]
-    run_test_command(cmd=run, cli_args=venv_test_args, cli_kwargs=test_kwargs)
+        # Should fail because of --no_venv
+        no_venv_test_args = ["test_venv_agent", "--use-outer-env"]
+        test_kwargs = {
+            "--registry-file": str(TEST_VENV_AGENT_DIR / "components.yaml")
+        }
+        with pytest.raises(ModuleNotFoundError):
+            run_test_command(
+                cmd=run, cli_args=no_venv_test_args, cli_kwargs=test_kwargs
+            )
+
+        # Should succeed because we will create a venv
+        venv_test_args = ["test_venv_agent"]
+        run_test_command(
+            cmd=run, cli_args=venv_test_args, cli_kwargs=test_kwargs
+        )
 
 
 def test_venv_repl(tmpdir):
-    _clean_up_sys_modules()
-    _confirm_modules_not_in_env()
-    venv_path = Path(tmpdir) / "reqs"
-    venv = VirtualEnv(venv_path=venv_path)
-    assert not venv_path.exists()
-    venv.create_virtual_env()
-    assert venv_path.exists()
-
-    # These packages are not found in our venv either
-    with venv:
+    with auto_revert_venv():
+        _clean_up_sys_modules()
         _confirm_modules_not_in_env()
+        venv_path = Path(tmpdir) / "reqs"
+        venv = VirtualEnv(venv_path=venv_path)
+        assert not venv_path.exists()
+        venv.create_virtual_env()
+        assert venv_path.exists()
 
-    req_file = TEST_VENV_AGENT_DIR / "requirements.txt"
-    venv.install_requirements_file(req_file)
+        # These packages are not found in our venv either
+        with venv:
+            _confirm_modules_not_in_env()
 
-    # import success
-    with venv:
-        import arrow  # noqa: F401 F811
+        req_file = TEST_VENV_AGENT_DIR / "requirements.txt"
+        venv.install_requirements_file(req_file)
 
-    # Fail because context manager __exit__ deactivates the venv
-    with pytest.raises(ModuleNotFoundError):
+        # import success
+        with venv:
+            import arrow  # noqa: F401 F811
+
+        # Fail because context manager __exit__ deactivates the venv
+        with pytest.raises(ModuleNotFoundError):
+            import bottle  # noqa: F401 F811
+
+        venv.activate()
         import bottle  # noqa: F401 F811
 
-    venv.activate()
-    import bottle  # noqa: F401 F811
-
-    venv.deactivate()
+        venv.deactivate()
 
 
 def test_setup_py_agent():
-    _clean_up_sys_modules()
-    _confirm_modules_not_in_env()
-    local_repo_spec = {
-        "local__setup_py_agent__repo": {
-            RepoSpecKeys.TYPE: "local",
-            RepoSpecKeys.PATH: "test_agents/setup_py_agent/",
+    with auto_revert_venv():
+        _clean_up_sys_modules()
+        _confirm_modules_not_in_env()
+        local_repo_spec = {
+            "local__setup_py_agent__repo": {
+                RepoSpecKeys.TYPE: "local",
+                RepoSpecKeys.PATH: "test_agents/setup_py_agent/",
+            }
         }
-    }
-    base_dir = Path(__file__).parent
-    agent_repo = Repo.from_spec(local_repo_spec, base_dir=base_dir)
-    agent_c = Component.from_repo(
-        repo=agent_repo,
-        identifier="BasicAgent",
-        file_path="./agent.py",
-        class_name="BasicAgent",
-        instantiate=True,
-        requirements_path="./setup.py",
-    )
-    agent_c.run("evaluate")
+        base_dir = Path(__file__).parent
+        agent_repo = Repo.from_spec(local_repo_spec, base_dir=base_dir)
+        agent_c = Component.from_repo(
+            repo=agent_repo,
+            identifier="BasicAgent",
+            file_path="./agent.py",
+            class_name="BasicAgent",
+            instantiate=True,
+            requirements_path="./setup.py",
+        )
+        agent_c.run("evaluate")
+
+
+def test_only_activate_venv_once():
+    with auto_revert_venv():
+        _clean_up_sys_modules()
+        _confirm_modules_not_in_env()
+        random_agent_repo = LocalRepo(
+            "random_agent_repo", local_dir=RANDOM_AGENT_DIR
+        )
+        print(random_agent_repo)
+        random_agent_component = Component.from_repo(
+            repo=random_agent_repo,
+            identifier="BasicAgent",
+            file_path="./agent.py",
+            class_name="BasicAgent",
+            instantiate=True,
+            requirements_path="./requirements.txt",
+        )
+        random_agent_component.get_object()
+        env_component_no_reqs = Component.from_repo(
+            repo=random_agent_repo,
+            identifier="Corridor1",
+            file_path="./environment.py",
+            class_name="Corridor",
+            instantiate=True,
+        )
+        # OK to add a dependency without reqs to a Component with active venv
+        random_agent_component.add_dependency(
+            env_component_no_reqs, attribute_name="env1"
+        )
+        random_agent_component.get_object()
+        env_component_reqs = Component.from_repo(
+            repo=random_agent_repo,
+            identifier="Corridor2",
+            file_path="./environment.py",
+            class_name="Corridor",
+            instantiate=True,
+            requirements_path="./requirements.txt",
+        )
+        # Should explode because venv is active and we're adding new reqs
+        with pytest.raises(Exception):
+            random_agent_component.add_dependency(
+                env_component_reqs, attribute_name="env2"
+            )


### PR DESCRIPTION
This PR makes it so that when we're building and running a Component DAG with one or more `requirements_path`'s defined, we only activate the virtual env built out of those requirements once and never deactivate.  

I think this is the most reasonable behavior given that:

* It is impossible to isolate dependencies for different components in CPython (see write up [here](https://docs.google.com/document/d/1i1AoTF63IUh9hgYBgxdBRsbBgwD8YvKJ9HbwRwR_L68/edit#heading=h.5skdbrwtmflo))
* Some libraries make changes to the environment when they are imported that they expect to persist (e.g. manipulation of the `sys.path`)
* We support the `get_object()` flow and that object expects to run in its environment.

I added a local check to `Component.add_dependency()` to make sure you weren't doing obviously bad things (adding a Component with requirements to a DAG after a venv was created and activated), but I didn't add any global checks.  Specifically, you could create two Components with different venvs and activate them sequentially and potentially get unexpected behavior.  This is a failure mode we might want to address in the future.

Fixes #324 