### PR TITLE
Fixes broken install of dev-requirements on apple silicon (Apple M1 Macbook Pro)

### DIFF
--- a/example_agents/rllib_agent/requirements.txt
+++ b/example_agents/rllib_agent/requirements.txt
@@ -3,7 +3,7 @@
 # Pass the following option to pip on linux to get the CPU only torch
 # -f https://download.pytorch.org/whl/cpu/torch_stable.html
 torch==1.10.2+cpu; sys_platform == 'linux'
-torch==1.10.2; sys_platform == 'windows'
+torch==1.10.2; sys_platform == 'win32'
 torch==1.10.2; sys_platform == 'darwin'
 ray[rllib]==1.10.0
 gym==0.21.0

--- a/example_agents/rllib_agent/requirements.txt
+++ b/example_agents/rllib_agent/requirements.txt
@@ -6,7 +6,7 @@ torch==1.10.2+cpu; sys_platform == 'linux'
 torch==1.10.2; sys_platform == 'win32'
 torch==1.10.2; sys_platform == 'darwin'
 ray[rllib]==1.10.0
-gym==0.21.0
+gym==0.19.0
 
 # agentos_pip_cmdline:
 #   linux:

--- a/example_agents/sb3_agent/requirements.txt
+++ b/example_agents/sb3_agent/requirements.txt
@@ -7,4 +7,4 @@ dm-env==1.5
 mlflow==1.23.1
 torch==1.9.1+cpu; sys_platform == 'linux'
 torch==1.9.1; sys_platform == 'windows'
-torch==1.9.1; sys_platform == 'darwin'
+torch==1.9.0; sys_platform == 'darwin'

--- a/example_agents/sb3_agent/requirements.txt
+++ b/example_agents/sb3_agent/requirements.txt
@@ -6,5 +6,5 @@ stable_baselines3==1.4.0
 dm-env==1.5
 mlflow==1.23.1
 torch==1.9.1+cpu; sys_platform == 'linux'
-torch==1.9.1; sys_platform == 'windows'
+torch==1.9.1; sys_platform == 'win32'
 torch==1.9.0; sys_platform == 'darwin'

--- a/example_agents/sb3_agent/requirements.txt
+++ b/example_agents/sb3_agent/requirements.txt
@@ -5,6 +5,6 @@
 stable_baselines3==1.4.0
 dm-env==1.5
 mlflow==1.23.1
-torch==1.9.1+cpu; sys_platform == 'linux'
-torch==1.9.1; sys_platform == 'win32'
-torch==1.9.0; sys_platform == 'darwin'
+torch==1.10.2+cpu; sys_platform == 'linux'
+torch==1.10.2; sys_platform == 'win32'
+torch==1.10.2; sys_platform == 'darwin'

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -71,9 +71,10 @@ def install_requirements():
     # On Apple Silicon, as of 3/23/22 using pip directly to install scipy and
     # grpcio is broken but conda installing them works and installs them as
     # pip packages.
-    if (sys.platform == "darwin" and
-        platform.processor() == "arm" and
-        conda_installed
+    if (
+        sys.platform == "darwin"
+        and platform.processor() == "arm"
+        and conda_installed
     ):
         _run(["conda", "install", "-y", "scipy", "grpcio"])
 

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -1,3 +1,4 @@
+import platform
 import subprocess
 import sys
 from pathlib import Path
@@ -57,6 +58,24 @@ def install_requirements():
         subprocess.check_call(["pip", "--version"], stdout=subprocess.DEVNULL)
     except (FileNotFoundError, subprocess.CalledProcessError):
         pip_installed = False
+
+    # check if conda is installed and valid
+    conda_installed = True
+    try:
+        subprocess.check_call(
+            ["conda", "--version"], stdout=subprocess.DEVNULL
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        conda_installed = False
+
+    # On Apple Silicon, as of 3/23/22 using pip directly to install scipy and
+    # grpcio is broken but conda installing them works and installs them as
+    # pip packages.
+    if (sys.platform == "darwin" and
+        platform.processor() == "arm" and
+        conda_installed
+    ):
+        _run(["conda", "install", "-y", "scipy", "grpcio"])
 
     if pip_installed:
         install_with_pip("pip")


### PR DESCRIPTION
Up until now,  on my Macbook Pro M1 I've been ignoring the rllib tests which have failed with a segfault.

However I recently:
1. switched to the arm64 version of brew (I previously had installed the x86 vesion which I guess was using rosetta for much of what it was installing?)
2. used that new brew to re-install conda
3. made a new env
4. installed scipy via conda (since installing scipy via pip tries compiling numpy on apple silicon which fails)
5. tried pip installing sb3 requirements, and this fails because apparently torch 1.9.1 is not available on MacOS w/ apple silicon, but 1.9.0 is.

so this changes the version of torch in the example_agent requirements.txt file to 1.9.0, which fixes the error on my Macbook Pro (MBP) M1.

Also, this PR updates the string we look for in sys.platform from "windows" to "win32". I looked at the test output on the github workflow windows machine and it was showing:

```
Ignoring torch: markers 'sys_platform == "linux"' don't match your environment
Ignoring torch: markers 'sys_platform == "darwin"' don't match your environment
Ignoring torch: markers 'sys_platform == "windows"' don't match your environment
```

Which seemed odd since I would expect it to be matching "windows", so I looked it up and per https://docs.python.org/3/library/sys.html?highlight=sys#sys.platform "win32" is the correct string, not "windows".

So this PR also fixes our use of that string in two example_agent requirements.txt files.