### PR TITLE
fix a broken test that wasn't caught in #328

### DIFF
--- a/pcs/registry.py
+++ b/pcs/registry.py
@@ -114,7 +114,9 @@ class Registry(abc.ABC):
                 "file_path": str(relative_path),
                 "instantiate": False,
             }
-            if repo.get_local_file_path(requirements_file).is_file():
+            if repo.get_local_file_path(
+                requirements_file, version=c_version
+            ).is_file():
                 component_init_kwargs.update(
                     {"requirements_path": str(requirements_file)}
                 )

--- a/pcs/repo.py
+++ b/pcs/repo.py
@@ -337,11 +337,7 @@ class GitHubRepo(Repo):
         clone_destination = (
             AOS_GLOBAL_REPOS_DIR / org_name / proj_name / version
         )
-        if clone_destination.exists():
-            porcelain.fetch(
-                repo=str(clone_destination), remote_location=self.url
-            )
-        else:
+        if not clone_destination.exists():
             clone_destination.mkdir(parents=True)
             porcelain.clone(
                 source=self.url, target=str(clone_destination), checkout=True

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -158,5 +158,5 @@ def test_registry_from_repo():
         requirements_file="dev-requirements.txt",
         version=TESTING_BRANCH_NAME,
     )
-    comp_name = f"module:agentos__component.py=={TESTING_BRANCH_NAME}"
+    comp_name = f"module:pcs__component.py=={TESTING_BRANCH_NAME}"
     assert comp_name in reg.to_dict()["components"]


### PR DESCRIPTION
One of our tests exercises `Registry.from_repo_inferred` but is failing because we forgot to update the module file we expected it to be loaded from after the file referenced (component.pay) moved from `AgentOS` to `PCs `.

This didn't cause a test failure during PR review because of a bug in [the way we are using] porcelain that results in some files in the master branch of any GitHub repo not getting removed when the repo's version is non-master.

This also removes a call to `porcelain.fetch()` that was added in https://github.com/agentos-project/agentos/commit/8d377914f8e153df2bf4429608aaac7ffb67ee32 that slows down the Registry.from_repo_inferred test `but didn't seem to fix the problem documented in #310