### PR TITLE
0.1.1 release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,7 +210,7 @@ Use the ``--help`` flag to learn more about other optional flags that
 changed).
 
 Notice that the build file puts the compiled docs into ``docs/<version_num>``
-where ``version_num`` comes from ``agentos/version.py``.
+where ``version_num`` comes from ``pcs/version.py``.
 
 Or you can build the docs manually (e.g., to control where output goes)::
 
@@ -272,7 +272,7 @@ Here are the steps for releasing AgentOS:
 
 #. Create a release pull request (PR) that:
 
-   * Removes "-alpha" suffix from the version number in ``agentos/version.py``.
+   * Removes "-alpha" suffix from the version number in ``pcs/version.py``.
    * Contains draft release notes (summary of major changes).
 
 #. Wait till the PR gets LGTMs from all other committers, then merge it.

--- a/documentation/includes/developing.rst
+++ b/documentation/includes/developing.rst
@@ -127,7 +127,7 @@ Use the ``--help`` flag to learn more about other optional flags that
 changed).
 
 Notice that the build file puts the compiled docs into ``docs/<version_num>``
-where ``version_num`` comes from ``agentos/version.py``.
+where ``version_num`` comes from ``pcs/version.py``.
 
 Or you can build the docs manually (e.g., to control where output goes)::
 
@@ -189,7 +189,7 @@ Here are the steps for releasing AgentOS:
 
 #. Create a release pull request (PR) that:
 
-   * Removes "-alpha" suffix from the version number in ``agentos/version.py``.
+   * Removes "-alpha" suffix from the version number in ``pcs/version.py``.
    * Contains draft release notes (summary of major changes).
 
 #. Wait till the PR gets LGTMs from all other committers, then merge it.

--- a/pcs/version.py
+++ b/pcs/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.1-alpha"
+VERSION = "0.1.1"


### PR DESCRIPTION
This is the release PR for version 0.1.1 of AgentOS and the Python Component System (PCS).

### Major Changes

* Allow a Component to be a managed module, as an alternative to the existing support for a Component being a managed class or class instance ([#295](https://github.com/agentos-project/agentos/pull/295))
* Integrate VirtualEnv management into Component ([#296](https://github.com/agentos-project/agentos/pull/296))
* Separation of AgentOS and PCS into different top-level modules.  Most non-RL-specific functionality of the project can now be accessed by importing module `pcs` ([#328](https://github.com/agentos-project/agentos/pull/328))



### Minor Changes

* Delete Component.Identifier and replace all uses of it with ComponentIdentifier ([#290](https://github.com/agentos-project/agentos/pull/290))
* Simplify ComponentIdentifier by making it a subtype of str ([#290](https://github.com/agentos-project/agentos/pull/290))
* Moved Component import and instantiation into `get_object()` ([#293](https://github.com/agentos-project/agentos/pull/293))
* Fix bugs in `build_docs.py` script ([#294](https://github.com/agentos-project/agentos/pull/294))
* Add isort as a part of code formatting ([#302](https://github.com/agentos-project/agentos/pull/302))
* VirtualEnv can be created from setup.py files ([#306](https://github.com/agentos-project/agentos/pull/306))
* Updates to values in RunCommandSpecKeys ([#313](https://github.com/agentos-project/agentos/pull/313))
* Better handling of `sys.path` during Component import ([#313](https://github.com/agentos-project/agentos/pull/313))
* Only activate a Component's virtual environment once with no deactivate ([#325](https://github.com/agentos-project/agentos/pull/325))
* Fixes for dev requirements installation on Mac M1 ([#326](https://github.com/agentos-project/agentos/pull/326))

### Other Notes

Previous release: #279 

