### PR TITLE
0.2.0 release

### DIFF
--- a/pcs/version.py
+++ b/pcs/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.1"
+VERSION = "0.2.0"


### PR DESCRIPTION
This is the release PR for version 0.2.0 of AgentOS and the Python Component System (PCS).

### Major Changes

* Allow a Component to be a managed module, as an alternative to the existing support for a Component being a managed class or class instance ([#295](https://github.com/agentos-project/agentos/pull/295))
* Integrate VirtualEnv management into Component ([#296](https://github.com/agentos-project/agentos/pull/296))
* Separation of AgentOS and PCS into different top-level modules.  Most non-RL-specific functionality of the project can now be accessed by importing module `pcs` ([#328](https://github.com/agentos-project/agentos/pull/328))



### Minor Changes

* Delete Component.Identifier and replace all uses of it with ComponentIdentifier ([#290](https://github.com/agentos-project/agentos/pull/290))
* Simplify ComponentIdentifier by making it a subtype of str ([#290](https://github.com/agentos-project/agentos/pull/290))
* Moved Component import and instantiation into `get_object()` ([#293](https://github.com/agentos-project/agentos/pull/293))
* Fix bugs in `build_docs.py` script ([#294](https://github.com/agentos-project/agentos/pull/294))
* Add isort as a part of code formatting ([#302](https://github.com/agentos-project/agentos/pull/302))
* VirtualEnv can be created from setup.py files ([#306](https://github.com/agentos-project/agentos/pull/306))
* Updates to values in RunCommandSpecKeys ([#313](https://github.com/agentos-project/agentos/pull/313))
* Better handling of `sys.path` during Component import ([#313](https://github.com/agentos-project/agentos/pull/313))
* Only activate a Component's virtual environment once with no deactivate ([#325](https://github.com/agentos-project/agentos/pull/325))
* Fixes for dev requirements installation on Mac M1 ([#326](https://github.com/agentos-project/agentos/pull/326))

### Other Notes

* We initially called this the 0.1.1 release, but then decided that the changes were big enough to call this the 0.2.0 release.  So, if you still find any references to 0.1.1, let us know (they should all point to this release now).  
* Previous release: #279 

