### PR TITLE
Add codespell and pyupgrade to our code formatting

### DIFF
--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -327,7 +327,7 @@ def _user_args_to_dict(arguments, argument_type="P"):
 def _instantiate_template_files(d, agent_name):
     AOS_PATH = Path(__file__).parent
     for file_path in _INIT_FILES:
-        with open(AOS_PATH / file_path, "r") as fin:
+        with open(AOS_PATH / file_path) as fin:
             with open(d / file_path.name, "w") as fout:
                 print(file_path)
                 content = fin.read()

--- a/agentos/core.py
+++ b/agentos/core.py
@@ -420,7 +420,7 @@ def rollouts(
 ):
     """
     :param policy: policy to use when simulating these episodes.
-    :param env_class: class to instatiate an env object from.
+    :param env_class: class to instantiate an env object from.
     :param num_rollouts: how many rollouts (i.e., episodes) to perform
     :param step_fn: a function to be called at each step of each rollout.
                     The function can have 2 or 3 parameters.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,8 +13,9 @@ sphinx_rtd_theme==1.0.0
 click>=7.0 # when updating, also update in ../setup.py
 
 # Tests requirements
-isort==5.10.1
-black==22.3.0
+isort>=5.10.1
+black>=22.3.0
+codespell>=2.1.0
 cloudpickle==1.3.0  # gym 0.17.1 in setup.py requires cloudpickle<1.4.0,>=1.2.0
 flake8==4.0.1
 pytest==6.2.5

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,6 +16,7 @@ click>=7.0 # when updating, also update in ../setup.py
 isort>=5.10.1
 black>=22.3.0
 codespell>=2.1.0
+pyupgrade>=2.32.0
 cloudpickle==1.3.0  # gym 0.17.1 in setup.py requires cloudpickle<1.4.0,>=1.2.0
 flake8==4.0.1
 pytest==6.2.5

--- a/documentation/design_docs/registry.rst
+++ b/documentation/design_docs/registry.rst
@@ -458,6 +458,6 @@ Revision History
 Further Reading
 ===============
 
-* `AgentOS Issue 68: Registery for Envs, Policies, and Agents <https://github.com/agentos-project/agentos/issues/68>`_
+* `AgentOS Issue 68: Registry for Envs, Policies, and Agents <https://github.com/agentos-project/agentos/issues/68>`_
 * `PEP 301 -- Package Index and Metadata for Distutils <https://www.python.org/dev/peps/pep-0301/>`_
 * `PEP 243 -- Module Repository Upload Mechanism <https://www.python.org/dev/peps/pep-0243/>`_

--- a/documentation/programming_agents.rst
+++ b/documentation/programming_agents.rst
@@ -54,7 +54,7 @@ returns an action. Policies must:
 
 Agents: putting it all together
 ================================
-The architeture and API that AgentOS provides for Agents is minimal in order to
+The architecture and API that AgentOS provides for Agents is minimal in order to
 provide flexibility, because different agents should be able to perform very
 different types of tasks. But it is also expected that Agents will be highly
 sophisticated. So then most of the complexity of agents will be outside of

--- a/example_agents/acme_dqn/network.py
+++ b/example_agents/acme_dqn/network.py
@@ -44,7 +44,7 @@ class TFModelSaver:
                             f"{save_as_name} from {save_path}."
                         )
                         return
-            except IOError as e:
+            except OSError as e:
                 print(f"failed to download artifacts: {e}")
         print(
             f"{cls.__name__}: No saved Tensorflow model "

--- a/example_agents/sb3_agent/sb3_run.py
+++ b/example_agents/sb3_agent/sb3_run.py
@@ -135,7 +135,7 @@ class SB3Run(AgentRun):
                     policy_path = cls._mlflow_client.download_artifacts(
                         run.info.run_id, name
                     )
-                except IOError:
+                except OSError:
                     continue  # No policy was logged in this run, keep trying.
                 print(f"SB3Run: Found last_logged SB3 policy '{name}'.")
                 return PPO.load(policy_path)

--- a/pcs/component_run.py
+++ b/pcs/component_run.py
@@ -159,8 +159,8 @@ class ComponentRun(Run):
     def _fetch_run_command(self) -> RunCommand:
         try:
             path = self.download_artifacts(self.RUN_COMMAND_REGISTRY_FILENAME)
-        except IOError as e:
-            raise IOError(
+        except OSError as e:
+            raise OSError(
                 f"RunCommand registry artifact not found in Run with id "
                 f"{self._mlflow_run_id}. {repr(e)}"
             )

--- a/pcs/registry.py
+++ b/pcs/registry.py
@@ -121,7 +121,7 @@ class Registry(abc.ABC):
                     {"requirements_path": str(requirements_file)}
                 )
             mod_component = Component(**component_init_kwargs)
-            # TODO: add depenendencies to component for every import
+            # TODO: add dependencies to component for every import
             #       statement in the file (or just the ones at the
             #       module level?)
             reg.add_component(mod_component)

--- a/pcs/repo.py
+++ b/pcs/repo.py
@@ -199,7 +199,7 @@ class Repo(abc.ABC):
                 raise BadGitStateException(error_msg)
         REMOTE_GIT_PREFIX = "refs/remotes"
         branch = porcelain.active_branch(self.porcelain_repo).decode("UTF-8")
-        full_id = f"{REMOTE_GIT_PREFIX}/{remote}/{branch}".encode("UTF-8")
+        full_id = f"{REMOTE_GIT_PREFIX}/{remote}/{branch}".encode()
         refs_dict = self.porcelain_repo.refs.as_dict()
         try:
             curr_remote_hash = refs_dict[full_id].decode("UTF-8")

--- a/pcs/run.py
+++ b/pcs/run.py
@@ -206,7 +206,7 @@ class Run:
                 for k, v in self.data.tags.items()
                 if not k.startswith("mlflow.")
             }
-            print(f"\tRun {self.identifier}: {filtered_tags}")
+            print(f"    Run {self.identifier}: {filtered_tags}")
         else:
             pprint.pprint(self.to_spec())
 

--- a/pcs/virtual_env.py
+++ b/pcs/virtual_env.py
@@ -229,7 +229,7 @@ class VirtualEnv:
     def _hash_req_paths(self, req_paths: Sequence) -> str:
         sorted_req_paths = self._sort_req_paths(req_paths)
         to_hash = hashlib.sha256()
-        to_hash.update("empty".encode("utf-8"))
+        to_hash.update(b"empty")
         for req_path in sorted_req_paths:
             with req_path.open() as file_in:
                 reqs_data = file_in.read()

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -86,7 +86,7 @@ shutil.copytree(API_DOC_INCLUDES, API_DOC_STUB_DIR, dirs_exist_ok=True)
 
 # Generate API Doc stub files.
 template = ""
-with open(pathlib.Path(API_DOC_TEMPLATE), "r") as template_f:
+with open(pathlib.Path(API_DOC_TEMPLATE)) as template_f:
     template = template_f.read()
 for source_dir in API_SOURCE_DIRS:
     for source_name in pathlib.Path(source_dir).glob(f"*{SOURCE_FILE_SUFFIX}"):

--- a/scripts/build_readme.py
+++ b/scripts/build_readme.py
@@ -31,7 +31,7 @@ with open(target_readme, "w") as readme_f:
 
     def include_docs_section(src_filename, separator_text):
         text_path = os.path.join(docs_dir, "includes", src_filename)
-        with open(text_path, "r") as f:
+        with open(text_path) as f:
             readme_f.write(f.read())
             readme_f.write(separator_text)
 

--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -30,19 +30,32 @@ CHECK_ARG = "--check"
 
 
 def format_file(path):
+    # Run codespell on every tracked file
+    codespell_cmd = ["codespell", path, "-w"]
+    if CHECK_ARG in sys.argv:
+        codespell_cmd.remove("-w")
+    _run_command(path, codespell_cmd)
+
+    # black and isort only run on Python
     extension = os.path.splitext(path)[1]
     if extension != ".py":
         return
+
+    # black to format code
     black_cmd = ["black", "--line-length=79", path]
+    if CHECK_ARG in sys.argv:
+        black_cmd.append("--check")
     _run_command(path, black_cmd)
+
+    # isort to arrange import statements:w
     isort_cmd = ["isort", "-m" "VERTICAL_HANGING_INDENT", "--tc", path]
+    if CHECK_ARG in sys.argv:
+        isort_cmd.append("--check")
     _run_command(path, isort_cmd)
 
 
 def _run_command(path, cmd):
     global returncode
-    if CHECK_ARG in sys.argv:
-        cmd.append("--check")
     result = run(cmd, stdout=PIPE, stderr=STDOUT)
     returncode = returncode | result.returncode
     out = result.stdout.decode("utf-8")

--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -36,7 +36,7 @@ def format_file(path):
         codespell_cmd.remove("-w")
     _run_command(path, codespell_cmd)
 
-    # black and isort only run on Python
+    # black, isort, and pyupgrade only run on Python
     extension = os.path.splitext(path)[1]
     if extension != ".py":
         return
@@ -52,6 +52,10 @@ def format_file(path):
     if CHECK_ARG in sys.argv:
         isort_cmd.append("--check")
     _run_command(path, isort_cmd)
+
+    # pyupgrade to upgrade deprecated lines
+    pyupgrade_cmd = ["pyupgrade", "--py37-plus", path]
+    _run_command(path, pyupgrade_cmd)
 
 
 def _run_command(path, cmd):

--- a/web/registry/tests/test_registry.py
+++ b/web/registry/tests/test_registry.py
@@ -47,7 +47,7 @@ class RegistryTestCases(TestCase):
     #     self.assertEqual(Component.objects.count(), 1)
     #     self.assertEqual(ComponentDependency.objects.count(), 0)
     #     self.assertEqual(Repo.objects.count(), 1)
-    #     # the ingest registry functionalty doesn't live under the Component
+    #     # the ingest registry functionality doesn't live under the Component
     #     # model/viewset anymore so this URL will be different.
     #     url = reverse("component-ingest-registry")
     #     yaml_file = open(self.static_dir / "test_spec_ingest.yaml")

--- a/web/registry/views.py
+++ b/web/registry/views.py
@@ -120,7 +120,7 @@ class RunViewSet(viewsets.ModelViewSet):
 
 
 # TODO: this should be very similar to RunViewSet but filter to just Runs
-#    from the Run table that have an agent and environemnt FK set.
+#    from the Run table that have an agent and environment FK set.
 class AgentRunViewSet(viewsets.ModelViewSet):
     queryset = Run.objects.filter(agent__isnull=False).order_by("-created")
     serializer_class = RunSerializer


### PR DESCRIPTION
I was taking a look at the [gym repo](https://github.com/openai/gym/blob/master/.pre-commit-config.yaml) and noticed that they were using [codespell](https://github.com/codespell-project/codespell) and [pyupgrade](https://github.com/asottile/pyupgrade) in addition to the other static formatting and linting packages we already use (black, isort, and flake8).  

I love me a good formatter and/or linter, so I added the ones we were missing.