### PR TITLE
Always use hashes for cached repos; dulwich refactor

### DIFF
--- a/pcs/git_manager.py
+++ b/pcs/git_manager.py
@@ -1,0 +1,488 @@
+import json
+import os
+import re
+import time
+from json.decoder import JSONDecodeError
+from pathlib import Path
+
+from dulwich import porcelain
+from dulwich.errors import NotGitRepository
+from dulwich.objectspec import parse_commit
+from dulwich.refs import LOCAL_BRANCH_PREFIX
+from dulwich.repo import Repo as PorcelainRepo
+
+from pcs.exceptions import BadGitStateException
+from pcs.utils import (
+    AOS_GLOBAL_REPOS_DIR,
+    clear_cache_path,
+    parse_github_web_ui_url,
+)
+
+
+class GitManager:
+    """
+    This manager class wraps low-level git/dulwich operations.
+    """
+
+    FULL_GIT_SHA1_RE = re.compile(r"\b[0-9a-f]{40}\b")
+
+    def get_public_url_and_hash(
+        self, full_path: Path, force: bool
+    ) -> (str, str):
+        """
+        Given a path to a a file or directory in a git repo, this returns a
+        GitHub repo URL where the current version of the file or directory is
+        publicly accessible AND the git hash of the current repo HEAD.  This
+        will raise an exception if any of the following checks are true:
+
+        1. The file/directory is not in a git repo.
+        2. The origin of this repo is not GitHub.
+        3. The current local branch and corresponding remote branch are not at
+           the same commit.
+        4. There are uncommitted changes locally
+
+        If ''force'' is True, checks 2, 3, and 4 above are ignored.
+        """
+
+        try:
+            porcelain_repo = PorcelainRepo.discover(full_path)
+        except NotGitRepository:
+            raise BadGitStateException(
+                f"No git repo with Component found: {full_path}"
+            )
+
+        self._check_for_local_changes(porcelain_repo, force)
+        url = self._check_for_github_url(porcelain_repo, force)
+        curr_head_hash = self._check_remote_branch_status(
+            porcelain_repo, force
+        )
+        return url, curr_head_hash
+
+    def get_prefixed_path_from_repo_root(self, full_path: Path) -> Path:
+        """
+        Given a full, absolute path to a file or directory, returns a path
+        relative to the innermost containing git repo.  For example, if
+        ``component_path`` is::
+
+            /foo/bar/baz/my_component.py
+
+        and a git repo lives in::
+
+            /foo/bar/.git/
+
+        then this would return::
+
+            baz/my_component.py
+        """
+        name = full_path.name
+        curr_path = full_path.parent
+        path_prefix = Path()
+        while curr_path != Path(curr_path.root):
+            try:
+                PorcelainRepo(curr_path)
+                return path_prefix / name
+            except NotGitRepository:
+                path_prefix = curr_path.name / path_prefix
+                curr_path = curr_path.parent
+        raise BadGitStateException(f"Unable to find repo: {full_path}")
+
+    def get_sha1_from_version(
+        self, org_name: str, project_name: str, version: str
+    ) -> str:
+        """
+        Given a ``version`` (a full git sha1 commit hash, a branch name, or a
+        tag name), returns the sha1 hash corresponding to that version.
+        """
+        match = re.match(self.FULL_GIT_SHA1_RE, version)
+        if match:
+            return match.group(0)
+        # See if we're referring to a branch
+        branches = self.get_branches(org_name, project_name)
+        for branch in branches:
+            if branch["name"] == version:
+                return branch["commit"]["sha"]
+        # See if we're referring to a tag
+        tags = self.get_tags(org_name, project_name)
+        for tag in tags:
+            if tag["name"] == version:
+                return tag["commit"]["sha"]
+        error_msg = (
+            f"Version {version} is not a full SHA1 hash and was "
+            f"also not found in branches or tags"
+        )
+        raise BadGitStateException(error_msg)
+
+    def _check_for_github_url(
+        self, porcelain_repo: PorcelainRepo, force: bool
+    ) -> str:
+        url = self._get_remote_url(porcelain_repo, force)
+        if url is None or "github.com" not in url:
+            error_msg = f"Remote must be on github, not {url}"
+            if force:
+                print(f"Warning: {error_msg}")
+            else:
+                raise BadGitStateException(error_msg)
+        return url
+
+    def _get_remote_url(
+        self,
+        porcelain_repo: PorcelainRepo,
+        force: bool,
+        remote_name: str = "origin",
+    ) -> str:
+        url = None
+        try:
+            REMOTE_KEY = (b"remote", remote_name.encode())
+            url = porcelain_repo.get_config()[REMOTE_KEY][b"url"].decode()
+            # remote, url = porcelain.get_remote_repo(porcelain_repo)
+        except KeyError:
+            error_msg = "Could not find remote repo"
+            if force:
+                print(f"Warning: {error_msg}")
+            else:
+                raise BadGitStateException(error_msg)
+        return url
+
+    def _check_remote_branch_status(
+        self, porcelain_repo: PorcelainRepo, force: bool
+    ) -> str:
+        curr_head_hash = porcelain_repo.head().decode()
+        url = self._get_remote_url(porcelain_repo, force)
+        project_name, repo_name, _, _ = parse_github_web_ui_url(url)
+        remote_commit_exists = self.sha1_hash_exists(
+            project_name, repo_name, curr_head_hash
+        )
+        if not remote_commit_exists:
+            error_msg = (
+                f"Current head hash {curr_head_hash} in "
+                f"PCS repo {porcelain_repo} is not on remote {url}. "
+                "Push your changes to your remote!"
+            )
+            if force:
+                print(f"Warning: {error_msg}")
+            else:
+                raise BadGitStateException(error_msg)
+        return curr_head_hash
+
+    def _check_for_local_changes(
+        self, porcelain_repo: PorcelainRepo, force: bool
+    ) -> None:
+        # Adapted from
+        # https://github.com/dulwich/dulwich/blob/master/dulwich/porcelain.py#L1200
+        # 1. Get status of staged
+        tracked_changes = porcelain.get_tree_changes(porcelain_repo)
+        # 2. Get status of unstaged
+        index = porcelain_repo.open_index()
+        normalizer = porcelain_repo.get_blob_normalizer()
+        filter_callback = normalizer.checkin_normalize
+        unstaged_changes = list(
+            porcelain.get_unstaged_changes(
+                index, porcelain_repo.path, filter_callback
+            )
+        )
+
+        uncommitted_changes_exist = (
+            len(unstaged_changes) > 0
+            or len(tracked_changes["add"]) > 0
+            or len(tracked_changes["delete"]) > 0
+            or len(tracked_changes["modify"]) > 0
+        )
+        if uncommitted_changes_exist:
+            print(
+                f"\nUncommitted changes: {tracked_changes} or "
+                f"{unstaged_changes}\n"
+            )
+            error_msg = "Commit all changes before freezing"
+            if force:
+                print(f"Warning: {error_msg}")
+            else:
+                raise BadGitStateException(error_msg)
+
+    def _get_default_repo_path(self, org_name: str, project_name: str) -> Path:
+        """
+        We checkout a "default repo" to map ref names to sha1 hashes.
+        """
+        global_default_path = AOS_GLOBAL_REPOS_DIR / "_default"
+        default_repo_path = global_default_path / org_name / project_name
+        url = f"https://github.com/{org_name}/{project_name}.git"
+        cloned = self._clone_repo(url=url, clone_destination=default_repo_path)
+        if not cloned:
+            self._maybe_fetch(default_repo_path)
+        return default_repo_path
+
+    def _maybe_fetch(self, default_repo_path: Path) -> None:
+        """
+        This function periodically runs `git fetch` in the "default" repo used
+        to map ref names to sha1 hashes.  We only update if we're a new
+        process or if we haven't updated in the last half hour.
+        """
+        PROC_KEY = "process_id"
+        TIME_KEY = "last_fetch_time"
+        default_info_path = Path(str(default_repo_path) + "-info.json")
+
+        def _do_fetch():
+            with open(default_info_path, "w") as fout:
+                json.dump({PROC_KEY: os.getpid(), TIME_KEY: time.time()}, fout)
+            print(f"GitManager: fetching {default_repo_path}...")
+            porcelain.fetch(porcelain.open_repo(default_repo_path))
+
+        if not default_info_path.exists():
+            _do_fetch()
+            return
+        with open(default_info_path) as fin:
+            try:
+                info = json.load(fin)
+            except JSONDecodeError:
+                _do_fetch()
+                return
+        sec_since_last_fetch = time.time() - info[TIME_KEY]
+        if info[PROC_KEY] != os.getpid() or sec_since_last_fetch > 1800:
+            _do_fetch()
+            return
+        print(f"GitManager: NOT fetching {default_repo_path}...")
+
+    def clear_repo_cache(
+        self, repo_cache_path: Path = None, assume_yes: bool = False
+    ) -> None:
+        """
+        Completely removes all the repos that have been created or checked
+        out in the ``repo_cache_path``. Pass True to ``assume_yes`` to run
+        non-interactively.
+        """
+        repo_cache_path = repo_cache_path or AOS_GLOBAL_REPOS_DIR
+        clear_cache_path(repo_cache_path, assume_yes)
+
+    def clone_repo(
+        self, org_name: str, project_name: str, version: str
+    ) -> Path:
+        """
+        Given a GitHub org, project name, and version (a sha1 commit hash,
+        branch name, or tag name), this will clone the repo at the version
+        into the PCS/AOS cache.
+        """
+        clone_destination = (
+            AOS_GLOBAL_REPOS_DIR / org_name / project_name / version
+        )
+        url = f"https://github.com/{org_name}/{project_name}.git"
+        self._clone_repo(
+            url=url, clone_destination=clone_destination, version=version
+        )
+        return clone_destination
+
+    def _clone_repo(
+        self, url: str, clone_destination: Path, version: str = None
+    ) -> bool:
+        cloned = False
+        if not clone_destination.exists():
+            clone_destination.mkdir(parents=True)
+            print(f"GitManager: cloning {url} to {str(clone_destination)}")
+            porcelain.clone(
+                source=url, target=str(clone_destination), checkout=True
+            )
+            if version:
+                self._checkout_version(clone_destination, version)
+            cloned = True
+        assert clone_destination.exists(), f"Unable to clone {url}"
+        return cloned
+
+    def _checkout_version(self, local_repo_path: Path, version: str) -> None:
+        curr_dir = os.getcwd()
+        os.chdir(local_repo_path)
+        repo = porcelain.open_repo(local_repo_path)
+        treeish = parse_commit(repo, version).sha().hexdigest()
+        # Checks for a clean working directory were failing on Windows, so
+        # force the checkout since this should be a clean clone anyway.
+        self._checkout(repo=repo, target=treeish, force=True)
+        os.chdir(curr_dir)
+
+    def get_branches(self, org_name: str, project_name: str) -> list:
+        """
+        Returns all the branches found in the GitHub repo at:
+
+        https://github.com/org_name/project_name
+
+        The data structure returned mirrors that GitHub API and looks like
+        the following:
+
+        [
+            {
+                'name': <tag_name>
+                'commit': {
+                    'sha': <sha1_hash>
+                }
+            },
+            ...
+        ]
+
+        """
+
+        return self._get_refs_with_prefix(
+            org_name, project_name, "refs/remotes/origin/"
+        )
+
+    def get_tags(self, org_name: str, project_name: str) -> list:
+        """
+        Returns all the tags found in the GitHub repo at:
+
+        https://github.com/org_name/project_name
+
+        The data structure returned mirrors that GitHub API and looks like
+        the following:
+
+        [
+            {
+                'name': <tag_name>
+                'commit': {
+                    'sha': <sha1_hash>
+                }
+            },
+            ...
+        ]
+
+        """
+        return self._get_refs_with_prefix(org_name, project_name, "refs/tags/")
+
+    # https://github.com/jelmer/dulwich/pull/898
+    def _checkout(
+        self, repo: PorcelainRepo, target: bytes, force: bool = False
+    ) -> None:
+        """
+        This code is taken from the currently unmerged (but partially
+        cherry-picked) code in https://github.com/jelmer/dulwich/pull/898
+        that adds checkout() functionality to the dulwich code base.
+
+        Switch branches or restore working tree files
+        Args:
+          repo: dulwich Repo object
+          target: branch name or commit sha to checkout
+        """
+        # check repo status
+        if not force:
+            index = repo.open_index()
+            for file in porcelain.get_tree_changes(repo)["modify"]:
+                if file in index:
+                    raise Exception(
+                        "trying to checkout when working directory not clean"
+                    )
+
+            normalizer = repo.get_blob_normalizer()
+            filter_callback = normalizer.checkin_normalize
+
+            unstaged_changes = list(
+                porcelain.get_unstaged_changes(
+                    index, repo.path, filter_callback
+                )
+            )
+            for file in unstaged_changes:
+                if file in index:
+                    raise Exception(
+                        "Trying to checkout when working directory not clean"
+                    )
+
+        current_tree = porcelain.parse_tree(repo, repo.head())
+        target_tree = porcelain.parse_tree(repo, target)
+
+        # update head
+        if (
+            target == b"HEAD"
+        ):  # do not update head while trying to checkout to HEAD
+            target = repo.head()
+        elif target in repo.refs.keys(base=LOCAL_BRANCH_PREFIX):
+            porcelain.update_head(repo, target)
+            target = repo.refs[LOCAL_BRANCH_PREFIX + target]
+        else:
+            porcelain.update_head(repo, target, detached=True)
+
+        # unstage files in the current_tree or target_tree
+        tracked_changes = []
+        for change in repo.open_index().changes_from_tree(
+            repo.object_store, target_tree.id
+        ):
+            file = (
+                change[0][0] or change[0][1]
+            )  # no matter the file is added, modified or deleted.
+            try:
+                current_entry = current_tree.lookup_path(
+                    repo.object_store.__getitem__, file
+                )
+            except KeyError:
+                current_entry = None
+            try:
+                target_entry = target_tree.lookup_path(
+                    repo.object_store.__getitem__, file
+                )
+            except KeyError:
+                target_entry = None
+
+            if current_entry or target_entry:
+                tracked_changes.append(file)
+        tracked_changes = [tc.decode("utf-8") for tc in tracked_changes]
+        repo.unstage(tracked_changes)
+
+        # reset tracked and unstaged file to target
+        normalizer = repo.get_blob_normalizer()
+        filter_callback = normalizer.checkin_normalize
+        unstaged_files = porcelain.get_unstaged_changes(
+            repo.open_index(), repo.path, filter_callback
+        )
+        saved_repo_path = repo.path
+        repo.path = str(repo.path)
+        for file in unstaged_files:
+            file_path = Path(repo.path) / file.decode()
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            porcelain.reset_file(repo, file.decode(), b"HEAD")
+        repo.path = saved_repo_path
+
+        # remove the untracked file which in the current_file_set
+        for file in porcelain.get_untracked_paths(
+            repo.path, repo.path, repo.open_index(), exclude_ignored=True
+        ):
+            # TODO: Code below is from the original dulwich PR; had trouble
+            # getting this to work on Windows; Untracked files sitting in repo
+            # weren't being properly removed. Went with a more direct approach.
+            #
+            # try:
+            #     current_tree.lookup_path(
+            #         repo.object_store.__getitem__, file.encode()
+            #     )
+            # except KeyError:
+            #     pass
+            # else:
+            #     os.remove(os.path.join(repo.path, file))
+
+            full_path = Path(repo.path) / Path(file)
+            if full_path.exists():
+                os.remove(full_path)
+
+    def _get_refs_with_prefix(
+        self, org_name: str, project_name: str, prefix: str
+    ) -> list:
+        default_repo_path = self._get_default_repo_path(org_name, project_name)
+        repo = porcelain.open_repo(default_repo_path)
+        refs = repo.get_refs()
+        results = []
+        for ref, sha1_hash in refs.items():
+            ref = ref.decode()
+            if not ref.startswith(prefix):
+                continue
+            name = ref.replace(prefix, "", 1)
+            results.append(
+                {"name": name, "commit": {"sha": sha1_hash.decode()}}
+            )
+        return results
+
+    def sha1_hash_exists(
+        self, org_name: str, project_name: str, sha1_hash: str
+    ) -> bool:
+        """
+        Checks if ``sha1_hash`` exists in the repo at:
+
+        https://github.com/<org_name>/<project_name>
+        """
+        default_repo_path = self._get_default_repo_path(org_name, project_name)
+        repo = porcelain.open_repo(default_repo_path)
+        try:
+            repo[sha1_hash.encode()]
+        except KeyError:
+            return False
+        return True

--- a/pcs/repo.py
+++ b/pcs/repo.py
@@ -1,22 +1,17 @@
 import abc
 import logging
-import os
 import sys
 import uuid
 from enum import Enum
 from pathlib import Path
 from typing import Dict, Tuple, TypeVar, Union
 
-from dulwich import porcelain
-from dulwich.errors import NotGitRepository
-from dulwich.objectspec import parse_commit, parse_ref
-from dulwich.repo import Repo as PorcelainRepo
-
-from pcs.exceptions import BadGitStateException, PythonComponentSystemException
+from pcs.exceptions import PythonComponentSystemException
+from pcs.git_manager import GitManager
 from pcs.identifiers import ComponentIdentifier, RepoIdentifier
 from pcs.registry import InMemoryRegistry, Registry
 from pcs.specs import NestedRepoSpec, RepoSpec, RepoSpecKeys, flatten_spec
-from pcs.utils import AOS_GLOBAL_REPOS_DIR, clear_cache_path, dulwich_checkout
+from pcs.utils import AOS_GLOBAL_REPOS_DIR, parse_github_web_ui_url
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +30,7 @@ class Repo(abc.ABC):
     is located.
     """
 
-    UNKNOWN_URL = "unknown_url"
+    GIT = GitManager()
 
     def __init__(self, identifier: str, default_version: str = None):
         self.identifier = identifier
@@ -85,16 +80,16 @@ class Repo(abc.ABC):
         url = f"https://github.com/{github_account}/{repo_name}"
         return GitHubRepo(identifier, url)
 
+    @classmethod
     def clear_repo_cache(
-        repo_cache_path: Path = None, assume_yes: bool = False
+        cls, repo_cache_path: Path = None, assume_yes: bool = False
     ) -> None:
         """
         Completely removes all the repos that have been created or checked
         out in the ``repo_cache_path``. Pass True to ``assume_yes`` to run
         non-interactively.
         """
-        repo_cache_path = repo_cache_path or AOS_GLOBAL_REPOS_DIR
-        clear_cache_path(repo_cache_path, assume_yes)
+        cls.GIT.clear_repo_cache(repo_cache_path, assume_yes)
 
     @abc.abstractmethod
     def to_spec(self, flatten: bool = False) -> RepoSpec:
@@ -139,9 +134,10 @@ class Repo(abc.ABC):
         force: bool = False,
     ) -> Tuple[str, str]:
         """
-        Given a path to a Component, this returns a git hash and GitHub repo
-        URL where the current version of the Component is publicly accessible.
-        This will raise an exception if any of the following checks are true:
+        Given a path to a Component, this returns the GitHub repo URL where the
+        current version of the Component is publicly accessible and the git
+        hash of the current version of the Component.  This will raise an
+        exception if any of the following checks are true:
 
         1. The Component is not in a git repo.
         2. The origin of this repo is not GitHub.
@@ -149,118 +145,19 @@ class Repo(abc.ABC):
            the same commit.
         4. There are uncommitted changes locally
 
-
         If ''force'' is True, checks 2, 3, and 4 above are ignored.
         """
         full_path = self.get_local_file_path(
             file_path, component_identifier.version
         )
         assert full_path.exists(), f"Path {full_path} does not exist"
-        try:
-            self.porcelain_repo = PorcelainRepo.discover(full_path)
-        except NotGitRepository:
-            raise BadGitStateException(
-                f"No git repo with Component found: {full_path}"
-            )
-
-        self._check_for_local_changes(force)
-        url = self._check_for_github_url(force)
-        curr_head_hash = self._check_remote_branch_status(force)
-        self.porcelain_repo = None
-        return url, curr_head_hash
-
-    def _check_for_github_url(self, force: bool) -> str:
-        url = self.UNKNOWN_URL
-        try:
-            remote, url = porcelain.get_remote_repo(self.porcelain_repo)
-        except IndexError:
-            error_msg = "Could not find remote repo"
-            if force:
-                print(f"Warning: {error_msg}")
-            else:
-                raise BadGitStateException(error_msg)
-        if url is None or "github.com" not in url:
-            error_msg = f"Remote must be on github, not {url}"
-            if force:
-                print(f"Warning: {error_msg}")
-            else:
-                raise BadGitStateException(error_msg)
-        return url
-
-    def _check_remote_branch_status(self, force: bool) -> str:
-        try:
-            remote, url = porcelain.get_remote_repo(self.porcelain_repo)
-        except IndexError:
-            error_msg = "Unable to get remote repo"
-            if force:
-                print(f"Warning: {error_msg}")
-                return "unknown_version"
-            else:
-                raise BadGitStateException(error_msg)
-        REMOTE_GIT_PREFIX = "refs/remotes"
-        branch = porcelain.active_branch(self.porcelain_repo).decode("UTF-8")
-        full_id = f"{REMOTE_GIT_PREFIX}/{remote}/{branch}".encode()
-        refs_dict = self.porcelain_repo.refs.as_dict()
-        try:
-            curr_remote_hash = refs_dict[full_id].decode("UTF-8")
-        except KeyError:
-            curr_remote_hash = None
-
-        curr_head_hash = self.porcelain_repo.head().decode("UTF-8")
-
-        if curr_head_hash != curr_remote_hash:
-            print(
-                f"\nBranch {remote}/{branch} "
-                "current commit differs from local:"
-            )
-            print(f"\t{remote}/{branch}: {curr_remote_hash}")
-            print(f"\tlocal/{branch}: {curr_head_hash}\n")
-            error_msg = (
-                f"Push your changes to {remote}/{branch} before freezing"
-            )
-            if force:
-                print(f"Warning: {error_msg}")
-            else:
-                raise BadGitStateException(error_msg)
-        return curr_head_hash
-
-    def _check_for_local_changes(self, force: bool) -> None:
-        # Adapted from
-        # https://github.com/dulwich/dulwich/blob/master/dulwich/porcelain.py#L1200
-        # 1. Get status of staged
-        tracked_changes = porcelain.get_tree_changes(self.porcelain_repo)
-        # 2. Get status of unstaged
-        index = self.porcelain_repo.open_index()
-        normalizer = self.porcelain_repo.get_blob_normalizer()
-        filter_callback = normalizer.checkin_normalize
-        unstaged_changes = list(
-            porcelain.get_unstaged_changes(
-                index, self.porcelain_repo.path, filter_callback
-            )
-        )
-
-        uncommitted_changes_exist = (
-            len(unstaged_changes) > 0
-            or len(tracked_changes["add"]) > 0
-            or len(tracked_changes["delete"]) > 0
-            or len(tracked_changes["modify"]) > 0
-        )
-        if uncommitted_changes_exist:
-            print(
-                f"\nUncommitted changes: {tracked_changes} or "
-                f"{unstaged_changes}\n"
-            )
-            error_msg = "Commit all changes before freezing"
-            if force:
-                print(f"Warning: {error_msg}")
-            else:
-                raise BadGitStateException(error_msg)
+        return self.GIT.get_public_url_and_hash(full_path, force)
 
     def get_prefixed_path_from_repo_root(
         self, identifier: ComponentIdentifier, file_path: str
     ) -> Path:
         """
-        Finds the 'component_path' relative to the repo containing the
+        Finds the ``component_path`` relative to the repo containing the
         Component.  For example, if ``component_path`` is::
 
             /foo/bar/baz/my_component.py
@@ -274,17 +171,7 @@ class Repo(abc.ABC):
             baz/my_component.py
         """
         full_path = self.get_local_file_path(file_path, identifier.version)
-        name = full_path.name
-        curr_path = full_path.parent
-        path_prefix = Path()
-        while curr_path != Path(curr_path.root):
-            try:
-                PorcelainRepo(curr_path)
-                return path_prefix / name
-            except NotGitRepository:
-                path_prefix = curr_path.name / path_prefix
-                curr_path = curr_path.parent
-        raise BadGitStateException(f"Unable to find repo: {full_path}")
+        return self.GIT.get_prefixed_path_from_repo_root(full_path)
 
 
 class GitHubRepo(Repo):
@@ -300,6 +187,7 @@ class GitHubRepo(Repo):
         # https repo link allows for cloning without unlocking your GitHub keys
         url = url.replace("git@github.com:", "https://github.com/")
         self.url = url
+        self.org_name, self.project_name, _, _ = parse_github_web_ui_url(url)
         self.local_repo_path = None
         self.porcelain_repo = None
 
@@ -321,50 +209,23 @@ class GitHubRepo(Repo):
         return flatten_spec(spec) if flatten else spec
 
     def get_local_repo_dir(self, version: str = None) -> Path:
-        version = version if version else self._default_version
-        local_repo_path = self._clone_repo(version)
-        self._checkout_version(local_repo_path, version)
+        version = self._get_valid_version_sha1(version)
+        local_repo_path = self.GIT.clone_repo(
+            self.org_name, self.project_name, version
+        )
         sys.stdout.flush()
         return local_repo_path
 
     def get_local_file_path(self, file_path: str, version: str = None) -> Path:
-        version = version if version else self._default_version
+        version = self._get_valid_version_sha1(version)
         local_repo_path = self.get_local_repo_dir(version)
         return (local_repo_path / file_path).absolute()
 
-    def _clone_repo(self, version: str) -> Path:
-        org_name, proj_name = self.url.split("/")[-2:]
-        clone_destination = (
-            AOS_GLOBAL_REPOS_DIR / org_name / proj_name / version
+    def _get_valid_version_sha1(self, version):
+        version = version if version else self._default_version
+        return self.GIT.get_sha1_from_version(
+            self.org_name, self.project_name, version
         )
-        if not clone_destination.exists():
-            clone_destination.mkdir(parents=True)
-            porcelain.clone(
-                source=self.url, target=str(clone_destination), checkout=True
-            )
-        assert clone_destination.exists(), f"Unable to clone {self.url}"
-        return clone_destination
-
-    def _checkout_version(self, local_repo_path: Path, version: str) -> None:
-        to_checkout = version if version else "master"
-        curr_dir = os.getcwd()
-        os.chdir(local_repo_path)
-        repo = porcelain.open_repo(local_repo_path)
-        treeish = None
-        # Is version a branch name?
-        try:
-            treeish = parse_ref(repo, f"origin/{to_checkout}")
-        except KeyError:
-            pass
-
-        # Is version a commit hash (long or short)?
-        if treeish is None:
-            treeish = parse_commit(repo, to_checkout).sha().hexdigest()
-
-        # Checks for a clean working directory were failing on Windows, so
-        # force the checkout since this should be a clean clone anyway.
-        dulwich_checkout(repo=repo, target=treeish, force=True)
-        os.chdir(curr_dir)
 
 
 # TODO: Convert LocalRepo to GitRepo and make GitHubRepo a subclass of it
@@ -383,16 +244,17 @@ class LocalRepo(Repo):
         if not local_dir:
             local_dir = f"{AOS_GLOBAL_REPOS_DIR}/{uuid.uuid4()}"
         self.type = RepoType.LOCAL
-        self.local_dir = Path(local_dir).absolute()
-        if self.local_dir.exists():
-            assert self.local_dir.is_dir(), (
-                f"local_dir {self.local_dir} passed to LocalRepo.__init__() "
-                f"with identifier '{self.identifier}' exists but is not a dir."
+        self.local_repo_path = Path(local_dir).absolute()
+        if self.local_repo_path.exists():
+            assert self.local_repo_path.is_dir(), (
+                f"local_dir {self.local_repo_path} passed to "
+                f"LocalRepo.__init__() with identifier '{self.identifier}'"
+                "exists but is not a dir."
             )
         else:
-            self.local_dir.mkdir(parents=True, exist_ok=True)
+            self.local_repo_path.mkdir(parents=True, exist_ok=True)
             logger.debug(
-                f"Created local_dir {self.local_dir} for "
+                f"Created local_dir {self.local_repo_path} for "
                 f"LocalRepo {self.identifier}."
             )
 
@@ -413,14 +275,14 @@ class LocalRepo(Repo):
         spec = {
             self.identifier: {
                 RepoSpecKeys.TYPE: self.type.value,
-                RepoSpecKeys.PATH: str(self.local_dir),
+                RepoSpecKeys.PATH: str(self.local_repo_path),
             }
         }
         return flatten_spec(spec) if flatten else spec
 
     def get_local_repo_dir(self, version: str = None) -> Path:
         assert version is None, "LocalRepos don't support versioning."
-        return self.local_dir
+        return self.local_repo_path
 
     def get_local_file_path(
         self, relative_path: str, version: str = None
@@ -432,4 +294,4 @@ class LocalRepo(Repo):
                 "If this is actually a versioned repo, use GithubRepo "
                 "or another versioned Repo type."
             )
-        return self.local_dir / relative_path
+        return self.local_repo_path / relative_path

--- a/pcs/repo.py
+++ b/pcs/repo.py
@@ -134,18 +134,14 @@ class Repo(abc.ABC):
         force: bool = False,
     ) -> Tuple[str, str]:
         """
-        Given a path to a Component, this returns the GitHub repo URL where the
-        current version of the Component is publicly accessible and the git
-        hash of the current version of the Component.  This will raise an
-        exception if any of the following checks are true:
+        Given a ComponentIdentifier and a path, this returns a GitHub repo
+        URL and a git hash.  This URL and hash is where the version (specified
+        by the ComponentIdentifier) of the file at ``file_path`` is publicly
+        accessible.
 
-        1. The Component is not in a git repo.
-        2. The origin of this repo is not GitHub.
-        3. The current local branch and corresponding remote branch are not at
-           the same commit.
-        4. There are uncommitted changes locally
-
-        If ''force'' is True, checks 2, 3, and 4 above are ignored.
+        A number of checks are performed during the course of this operation.
+        Pass ``force=True`` to make failure of optional checks non-fatal.  see
+        ``GitManager.get_public_url_and_hash()`` for more details.
         """
         full_path = self.get_local_file_path(
             file_path, component_identifier.version

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -44,7 +44,7 @@ def test_local_to_from_registry():
     reg = repo.to_registry()
     repo_from_reg = Repo.from_registry(reg, "test_id")
     assert repo.identifier == repo_from_reg.identifier
-    assert repo.local_dir == repo_from_reg.local_dir
+    assert repo.local_repo_path == repo_from_reg.local_repo_path
 
 
 def test_repo_checkout_bug():


### PR DESCRIPTION
This PR doesn't change any public functionality, just how we use dulwich to manage the repo cache.  Main changes:

*  I collected all the dulwich functionality scattered around `repo.py` and `utils.py` and dropped it into a `GitManager` class that `repo.py` now uses for lower-level git functions.
* We map all "versions" (sha1 hashes, branch names, or tag names) to a sha1 hash and then create a repo specifically for that hash in the cache.
* We also checkout a "default repo" for each GitHub project which isn't used at PCS runtime other than to map tag and branch names to sha1 hashes and to check what commits exist on the remote.
* We occasionally run a fetch on the default repo (once per process touching it and/or every 30 minutes in the case of long running processes) to get updated refs.

I'm going to rebase my papag work branch and make sure this addresses the repo issues we've been seeing.