### PR TITLE
Git manager optimization

### DIFF
--- a/pcs/git_manager.py
+++ b/pcs/git_manager.py
@@ -271,7 +271,6 @@ class GitManager:
         if sec_since_last_fetch > 1800:
             _do_fetch()
             return
-        print(f"GitManager: NOT fetching {default_repo_path}...")
 
     def clear_repo_cache(
         self, repo_cache_path: Path = None, assume_yes: bool = False


### PR DESCRIPTION
Small optimization to the `GitManager`.  Because we've already cloned the repo in the `_default` cache, we don't actually have to pull from GitHub to clone the repo at a particular sha1.  Instead, we just clone the local default repo and checkout at the hash.