### PR TITLE
Fix small bug in demo papag script

### DIFF
--- a/documentation/demos/demo_papag_in_py_repl.py
+++ b/documentation/demos/demo_papag_in_py_repl.py
@@ -3,7 +3,7 @@ from pcs import ArgumentSet, Component
 # from pcs.registry import WebRegistry
 
 papag_agent = Component.from_registry_file(
-    "example_agents/papag/components.yaml", "agent"
+    "example_agents/papag/components.yaml", "papag_agent"
 ).to_versioned_component()
 
 a2c_pong_arg_set = ArgumentSet.from_yaml(


### PR DESCRIPTION
Uses the new name of the SB3 agent (`sb3_agent` instead of `agent`) in `documentation/demos/demo_papag_in_py_repl.py`.

I'm just going to merge because this fix is small!