### PR TITLE
Handle multiple remote scenario better

### DIFF
--- a/example_agents/gh_sb3_agent/components.yaml
+++ b/example_agents/gh_sb3_agent/components.yaml
@@ -1,37 +1,53 @@
 repos:
-    aos_github:
+    sb3_agent_gh:
         type: github
-        url: https://github.com/agentos-project/agentos.git
+        url: git@github.com:agentos-project/agentos.git
 
+    openai_gym:
+        type: github
+        url: git@github.com:openai/gym.git
+
+    stable_baselines3:
+        type: github
+        url: https://github.com/DLR-RM/stable-baselines3.git
+
+    mgbellemare_ale:
+        type: github
+        url: https://github.com/mgbellemare/Arcade-Learning-Environment.git
 
 components:
-    agent==test_staging:
-        repo: aos_github
-        file_path: example_agents/sb3_agent/agent.py
+    sb3_agent==test_staging:
+        repo: sb3_agent_gh
+        file_path: ./example_agents/sb3_agent/agent.py
         class_name: SB3PPOAgent
         instantiate: True
+        requirements_path: ./requirements.txt
         dependencies:
-            environment: environment==test_staging
+            AtariEnv: AtariEnv==db3728264f382402120913d76c4fa0dc320ef59f
+            CartPoleEnv: CartPoleEnv==4ede9280f9c477f1ca09929d10cdc1e1ba1129f1
+            PPO: PPO==21f6a474a4755996709efee8c0aab309df905cbf
             SB3AgentRun: SB3AgentRun==test_staging
-            blah: agent==test_staging
+    
+    AtariEnv==db3728264f382402120913d76c4fa0dc320ef59f:
+        repo: mgbellemare_ale
+        file_path: ./src/gym/envs/atari/environment.py
+        class_name: AtariEnv
+        instantiate: False
 
-    agent==test_staging:
-        repo: aos_github
-        file_path: example_agents/sb3_agent/agent.py
-        class_name: SB3PPOAgent
-        instantiate: True
-        dependencies:
-            environment: environment==test_staging
-            SB3AgentRun: SB3AgentRun==test_staging
+    CartPoleEnv==4ede9280f9c477f1ca09929d10cdc1e1ba1129f1:
+        repo: openai_gym
+        file_path: ./gym/envs/classic_control/cartpole.py
+        class_name: CartPoleEnv
+        instantiate: False
 
-    environment==test_staging:
-        repo: aos_github
-        file_path: example_agents/sb3_agent/environment.py
-        class_name: CartPole
-        instantiate: True
+    PPO==21f6a474a4755996709efee8c0aab309df905cbf:
+        repo: stable_baselines3
+        file_path: ./stable_baselines3/ppo/ppo.py
+        class_name: PPO
+        instantiate: False
 
     SB3AgentRun==test_staging:
-        repo: aos_github
-        file_path: example_agents/sb3_agent/sb3_run.py
+        repo: sb3_agent_gh
+        file_path: ./example_agents/sb3_agent/sb3_run.py
         class_name: SB3Run
         instantiate: False

--- a/pcs/git_manager.py
+++ b/pcs/git_manager.py
@@ -55,8 +55,7 @@ class GitManager:
             )
 
         self._check_for_local_changes(porcelain_repo, force)
-        url = self._check_for_github_url(porcelain_repo, force)
-        curr_head_hash = self._check_remote_branch_status(
+        url, curr_head_hash = self._check_remote_branch_status(
             porcelain_repo, force
         )
         return url, curr_head_hash
@@ -115,84 +114,48 @@ class GitManager:
         )
         raise BadGitStateException(error_msg)
 
-    def _get_remote_url(
-        self,
-        porcelain_repo: PorcelainRepo,
-        force: bool,
-        remote: str = "origin",
-    ) -> str:
-        url_or_path = self._get_remote_uri(porcelain_repo, force, remote)
-        # If path, assume cloned from default repo and find default repo URL.
-        if Path(url_or_path).exists():
-            with porcelain.open_repo_closing(url_or_path) as local_repo:
-                url = self._get_remote_uri(local_repo, force)
-        else:
-            url = url_or_path
-        return url
-
-    def _check_for_github_url(
-        self, porcelain_repo: PorcelainRepo, force: bool
-    ) -> str:
-        try:
-            remote = porcelain.get_branch_remote(porcelain_repo)
-        except IndexError:
-            remote = b"origin"
-        url = self._get_remote_url(
-            porcelain_repo, force, remote=remote.decode()
-        )
-        if url is None or "github.com" not in url:
-            error_msg = f"Remote must be on github, not {url}"
-            if force:
-                print(f"Warning: {error_msg}")
-            else:
-                raise BadGitStateException(error_msg)
-        return url
-
-    def _get_remote_uri(
-        self,
-        porcelain_repo: PorcelainRepo,
-        force: bool,
-        remote_name: str = "origin",
-    ) -> str:
-        """Can return a local path string or a URL."""
-        url = None
-        try:
-            REMOTE_KEY = (b"remote", remote_name.encode())
-            url = porcelain_repo.get_config()[REMOTE_KEY][b"url"].decode()
-        except KeyError:
-            error_msg = "Could not find remote repo"
-            if force:
-                print(f"Warning: {error_msg}")
-            else:
-                raise BadGitStateException(error_msg)
-        return url
+    def _get_all_remotes(self, porcelain_repo: PorcelainRepo) -> list:
+        repo_config = porcelain_repo.get_config()
+        remotes = []
+        for el in repo_config:
+            if len(el) != 2 or el[0] != b"remote":
+                continue
+            remotes.append((el[1].decode(), repo_config[el][b"url"].decode()))
+        if len(remotes) == 1:
+            remote_name, remote_uri = remotes[0]
+            # If path, assume a default repo clone and find default repo URLs.
+            if remote_name == "origin" and Path(remote_uri).exists():
+                with porcelain.open_repo_closing(remote_uri) as local_repo:
+                    return self._get_all_remotes(local_repo)
+        return remotes
 
     def _check_remote_branch_status(
         self, porcelain_repo: PorcelainRepo, force: bool
     ) -> str:
         curr_head_hash = porcelain_repo.head().decode()
-        try:
-            remote = porcelain.get_branch_remote(porcelain_repo)
-        except IndexError:
-            remote = b"origin"
-        url = self._get_remote_url(
-            porcelain_repo, force, remote=remote.decode()
-        )
-        project_name, repo_name, _, _ = parse_github_web_ui_url(url)
-        remote_commit_exists = self.sha1_hash_exists(
-            project_name, repo_name, curr_head_hash
-        )
-        if not remote_commit_exists:
-            error_msg = (
-                f"Current head hash {curr_head_hash} in "
-                f"PCS repo {porcelain_repo} is not on remote {url}. "
-                "Push your changes to your remote!"
+        all_remotes = self._get_all_remotes(porcelain_repo)
+        github_url = None
+        for remote_name, remote_url in all_remotes:
+            if "github.com" not in remote_url:
+                continue
+            github_url = remote_url
+            project_name, repo_name, _, _ = parse_github_web_ui_url(github_url)
+            remote_commit_exists = self.sha1_hash_exists(
+                project_name, repo_name, curr_head_hash
             )
-            if force:
-                print(f"Warning: {error_msg}")
-            else:
-                raise BadGitStateException(error_msg)
-        return curr_head_hash
+            if remote_commit_exists:
+                return github_url, curr_head_hash
+
+        error_msg = (
+            f"Current head hash {curr_head_hash} in PCS repo "
+            f"{porcelain_repo} is not on any remote {all_remotes}. "
+            "Push your changes to a GitHub remote!"
+        )
+        if force:
+            print(f"Warning: {error_msg}")
+        else:
+            raise BadGitStateException(error_msg)
+        return github_url, curr_head_hash
 
     def _check_for_local_changes(
         self, porcelain_repo: PorcelainRepo, force: bool

--- a/tests/example_agents/test_gh_sb3.py
+++ b/tests/example_agents/test_gh_sb3.py
@@ -1,7 +1,7 @@
 from agentos.cli import run
 from tests.utils import GH_SB3_AGENT_DIR, run_test_command
 
-test_args = ["agent", "--use-outer-env"]
+test_args = ["sb3_agent", "--use-outer-env"]
 test_kwargs = {"--registry-file": str(GH_SB3_AGENT_DIR / "components.yaml")}
 
 

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -51,14 +51,14 @@ def test_flatten_spec():
 
 def test_flatten_versioned_spec():
     reg = Registry.from_yaml(GH_SB3_AGENT_DIR / "components.yaml")
-    rand_comp_spec = reg.get_component_spec("agent", "test_staging")
-    full_comp_id = "agent==test_staging"
+    rand_comp_spec = reg.get_component_spec("sb3_agent", "test_staging")
+    full_comp_id = "sb3_agent==test_staging"
     assert full_comp_id in rand_comp_spec.keys()
-    assert rand_comp_spec[full_comp_id]["repo"] == "aos_github"
+    assert rand_comp_spec[full_comp_id]["repo"] == "sb3_agent_gh"
 
     flattened = flatten_spec(rand_comp_spec)
     assert flattened["identifier"] == full_comp_id
-    assert flattened["name"] == "agent"
+    assert flattened["name"] == "sb3_agent"
     assert flattened["version"] == "test_staging"
 
     nested = unflatten_spec(flattened)
@@ -70,5 +70,5 @@ def test_flatten_versioned_spec():
 
     # make sure we used deepcopy
     flattened["repo"] = "update_repo"
-    assert rand_comp_spec[full_comp_id]["repo"] == "aos_github"
-    assert nested[full_comp_id]["repo"] == "aos_github"
+    assert rand_comp_spec[full_comp_id]["repo"] == "sb3_agent_gh"
+    assert nested[full_comp_id]["repo"] == "sb3_agent_gh"


### PR DESCRIPTION
Another small tweak to `github_manager.py` to handle remotes better.  

I was working on a local branch that was tracking your branch `spec_structure_revamp` on your agentos fork at `andyk/agentos` and pushing my changes to branch `spec_structure_revamp` on my agentos fork at `nickjalbert/agentos`.  Our git-handling code was getting confused because it wasn't seeing my commits on the tracking branch in your fork (even though they were publicly available on my fork).  

This PR updates our code to check all remotes to see if the current commit is available on any of the ones that point to GitHub.  I think this make the `remote` argument unnecessary because we'll check all remotes regardless of the name.

