### PR TITLE
Fix pip dependency resolver issue

### DIFF
--- a/example_agents/acme_dqn/requirements.txt
+++ b/example_agents/acme_dqn/requirements.txt
@@ -95,7 +95,7 @@ PyVirtualDisplay==2.2
 PyYAML==5.4.1
 querystring-parser==1.2.4
 qute==3.0.11
-regex==2021.7.6
+regex==2021.8.28
 requests==2.21.0
 requests-oauthlib==1.3.0
 retrying==1.3.3

--- a/example_agents/acme_r2d2/requirements.txt
+++ b/example_agents/acme_r2d2/requirements.txt
@@ -95,7 +95,7 @@ PyVirtualDisplay==2.2
 PyYAML==5.4.1
 querystring-parser==1.2.4
 qute==3.0.11
-regex==2021.7.6
+regex==2021.8.28
 requests==2.21.0
 requests-oauthlib==1.3.0
 retrying==1.3.3


### PR DESCRIPTION
Small fix in the acme requirements to manually resolve a pip dependency conflict that significantly slows down the environment setup.

Brings dependency install time down from [~11ish minutes](https://github.com/agentos-project/agentos/runs/6830742508) to [~4ish minutes](https://github.com/agentos-project/agentos/runs/6831176117) on Ubuntu.