### PR TITLE
Add outer_run to AgentRun spec

### DIFF
--- a/agentos/agent_run.py
+++ b/agentos/agent_run.py
@@ -7,7 +7,6 @@ from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME
 
 from pcs.mlflow_run import MLflowRun
 from pcs.output import Output
-from pcs.registry import InMemoryRegistry, Registry
 
 _EPISODE_KEY = "episode_count"
 _STEP_KEY = "step_count"
@@ -25,7 +24,7 @@ _RUN_STATS_MEMBERS = [
 
 RunStats = namedtuple("RunStats", _RUN_STATS_MEMBERS)
 
-SPEC_ATTRS = []
+SPEC_ATTRS = ["outer_run"]
 
 
 class AgentRun(MLflowRun):
@@ -257,28 +256,6 @@ class AgentRun(MLflowRun):
                 "reward": reward,
             }
         )
-
-    def to_registry(
-        self,
-        registry: Registry = None,
-        recurse: bool = True,
-        include_artifacts: bool = False,
-    ) -> Registry:
-        if not registry:
-            registry = InMemoryRegistry()
-        # TODO - push artifacts to registry
-        if recurse:
-            if self.outer_run:
-                self.outer_run.to_registry(
-                    registry=registry,
-                    recurse=recurse,
-                )
-            if self.model_input_run:
-                self.model_input_run.to_registry(
-                    registry=registry,
-                    recurse=recurse,
-                )
-        return super().to_registry(registry=registry)
 
     def end(
         self,


### PR DESCRIPTION
Small change that adds the `outer_run` to the `AgentRun` spec.  Let's us get rid of the custom `to_registry()` function (for now).  Now we end up with specs on web that look like:

```
 {
            "identifier": "382dd72097d18bf7ef21fa6a6bd4bc135e313f6e",
            "identifier_link": "http://localhost:8000/api/v1/components/382dd72097d18bf7ef21fa6a6bd4bc135e313f6e/",
            "body": {
                "data": {
                    "tags": {
                        "run_type": "evaluate",
                        "pcs.is_run": "True",
                        "mlflow.user": "nickj",
                        "sb3_agent_run": "True",
                        "mlflow.runName": "AgentOS evaluate with Agent 'ed3bfcf02dc95c6887239a0218328d0f12531c78' and Env '8f94030e78e50ee997632918efee74469e099fa7'",
                        "agent_identifier": "ed3bfcf02dc95c6887239a0218328d0f12531c78",
                        "pcs.is_agent_run": "True",
                        "mlflow.parentRunId": "670122e9b67048fc85d9c2d002996e26",
                        "mlflow.source.name": "/home/nickj/agentos/lean-env/bin/agentos",
                        "mlflow.source.type": "LOCAL",
                        "environment_identifier": "8f94030e78e50ee997632918efee74469e099fa7",
                        "mlflow.source.git.commit": "0c31041bb5eb11c64400432c1f8e9e04020f6f8f"
                    },
                    "metrics": {
                        "max_reward": 108.0,
                        "min_reward": 35.0,
                        "step_count": 528.0,
                        "mean_reward": 52.8,
                        "episode_count": 10.0,
                        "median_reward": 49.0,
                        "training_step_count": 0.0,
                        "training_episode_count": 0.0
                    }
                },
                "info": {
                    "run_id": "813300913db948c78ccedf29c0860725",
                    "status": "FINISHED",
                    "user_id": "unknown",
                    "end_time": 1655035712997,
                    "run_uuid": "813300913db948c78ccedf29c0860725",
                    "start_time": 1655035712813,
                    "artifact_uri": "file:///home/nickj/agentos/example_agents/sb3_agent/mlruns/0/813300913db948c78ccedf29c0860725/artifacts",
                    "experiment_id": "0",
                    "lifecycle_stage": "active"
                },
                "type": "AgentRun",
                "outer_run": "spec:04392e1ea698657b81699e7c85f1c7e475dd8004",
                "experiment_id": "0"
            }
        },
        {
            "identifier": "04392e1ea698657b81699e7c85f1c7e475dd8004",
            "identifier_link": "http://localhost:8000/api/v1/components/04392e1ea698657b81699e7c85f1c7e475dd8004/",
            "body": {
                "data": {
                    "tags": {
                        "pcs.is_run": "True",
                        "mlflow.user": "nickj",
                        "mlflow.runName": "Running function 'evaluate' on Component 'ed3bfcf'.",
                        "pcs.command_id": "ecb956bfc5fac3c16763591c2c28f1352004c336",
                        "mlflow.source.name": "/home/nickj/agentos/lean-env/bin/agentos",
                        "mlflow.source.type": "LOCAL",
                        "pcs.is_component_run": "True",
                        "mlflow.source.git.commit": "0c31041bb5eb11c64400432c1f8e9e04020f6f8f"
                    }
                },
                "info": {
                    "run_id": "670122e9b67048fc85d9c2d002996e26",
                    "status": "FINISHED",
                    "user_id": "unknown",
                    "end_time": 1655035713009,
                    "run_uuid": "670122e9b67048fc85d9c2d002996e26",
                    "start_time": 1655035712741,
                    "artifact_uri": "file:///home/nickj/agentos/example_agents/sb3_agent/mlruns/0/670122e9b67048fc85d9c2d002996e26/artifacts",
                    "experiment_id": "0",
                    "lifecycle_stage": "active"
                },
                "type": "Output",
                "command": "spec:ecb956bfc5fac3c16763591c2c28f1352004c336",
                "experiment_id": "0"
            }
        },
        ...
``` 