### PR TITLE
Port leaderboard home page to new Component model

### DIFF
--- a/agentos/agent_run.py
+++ b/agentos/agent_run.py
@@ -7,7 +7,6 @@ from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME
 
 from pcs.mlflow_run import MLflowRun
 from pcs.output import Output
-from pcs.registry import InMemoryRegistry, Registry
 
 _EPISODE_KEY = "episode_count"
 _STEP_KEY = "step_count"
@@ -25,7 +24,7 @@ _RUN_STATS_MEMBERS = [
 
 RunStats = namedtuple("RunStats", _RUN_STATS_MEMBERS)
 
-SPEC_ATTRS = []
+SPEC_ATTRS = ["outer_run"]
 
 
 class AgentRun(MLflowRun):
@@ -257,28 +256,6 @@ class AgentRun(MLflowRun):
                 "reward": reward,
             }
         )
-
-    def to_registry(
-        self,
-        registry: Registry = None,
-        recurse: bool = True,
-        include_artifacts: bool = False,
-    ) -> Registry:
-        if not registry:
-            registry = InMemoryRegistry()
-        # TODO - push artifacts to registry
-        if recurse:
-            if self.outer_run:
-                self.outer_run.to_registry(
-                    registry=registry,
-                    recurse=recurse,
-                )
-            if self.model_input_run:
-                self.model_input_run.to_registry(
-                    registry=registry,
-                    recurse=recurse,
-                )
-        return super().to_registry(registry=registry)
 
     def end(
         self,

--- a/agentos/agent_run.py
+++ b/agentos/agent_run.py
@@ -24,7 +24,7 @@ _RUN_STATS_MEMBERS = [
 
 RunStats = namedtuple("RunStats", _RUN_STATS_MEMBERS)
 
-SPEC_ATTRS = ["outer_run"]
+SPEC_ATTRS = ["outer_run", "model_input_run"]
 
 
 class AgentRun(MLflowRun):

--- a/web/leaderboard/templates/leaderboard/index.html
+++ b/web/leaderboard/templates/leaderboard/index.html
@@ -22,58 +22,70 @@ $(document).ready( function () {
 
   <div class="content">
 
-      {% if env_dict %}
-          {% for env, run_list in env_dict.items %}
-              <div class="box" style="padding: 15px">
-              <h1 class="title is-1">{{ env.class_name }}
-                  <a href="{% url 'component-detail' env.identifier %}" style="font-size:0.35em">{{ env.identifier|truncatechars:20 }}</a>
-              </h1>
-              <table id="myTable" class="display table">
-                  <thead>
-                      <tr>
-                          <th>Timestamp</th>
-                          <th>Agent</th>
-                          <th>Run ID</th>
-                          <th>Run Description</th>
-                          <th>Avg. Reward</th>
-                          <th># Training Episodes</th>
-                          <th>#Training Steps</th>
-                      </tr>
-                  </thead>
-                  <tbody>
-                      {% for run in run_list %}
-                          <tr>
-                              <td><span style="font-size: 0.85em">{{ run.start_time }}</span></td>
-                              <td><a href="{% url 'component-detail' run.agent.identifier %}">{{ run.agent.name }}</a></td>
-                              <td><a href="run/{{ run.identifier }}">{{ run.identifier|truncatechars:7 }}</a></td>
-                              <td>
-                                  <a href="run/{{ run.identifier }}">
-                                      {% for k, v in run.data.tags.items %}
-                                          {% if k == "mlflow.runName" %}
-                                              {{ v|truncatechars:40 }}
-                                          {% endif %}
-                                      {% endfor %}
-                                  </a>
-                              </td>
-                              {%  for metric_name, metric_val in run.data.metrics.items %}
-                                  {% if metric_name == "mean_reward" %}
-                                      <td>{{ metric_val|floatformat:"g" }}</td>
-                                  {% endif %}
-                                  {% if metric_name == "training_episode_count" %}
-                                      <td>{{ metric_val|floatformat:"g" }}</td>
-                                  {% endif %}
-                                  {% if metric_name == "training_step_count" %}
-                                      <td>{{ metric_val|floatformat:"g" }}</td>
-                                  {% endif %}
-                              {% endfor %}
-                          </tr>
-                      {%  endfor %}
-                  </tbody>
-              </table>
-              </div>
-          {% endfor %}
+    {% if env_dict %}
+      {% for env, run_list in env_dict.items %}
+        <div class="box" style="padding: 15px">
+          <h1 class="title is-1">{{ env.class_name }}
+            <a
+              href="{% url 'component-detail' env.identifier %}"
+              style="font-size:0.35em"
+            >
+              {{ env.body.name | truncatechars:20 }}
+            </a>
+          </h1>
+          <table id="myTable" class="display table">
+            <thead>
+                <tr>
+                    <th>Timestamp</th>
+                    <th>Agent</th>
+                    <th>Run ID</th>
+                    <th>Run Description</th>
+                    <th>Avg. Reward</th>
+                    <th># Training Episodes</th>
+                    <th>#Training Steps</th>
+                </tr>
+            </thead>
+            <tbody>
+              {% for run in run_list %}
+                <tr>
+                  <td>
+                    <span style="font-size: 0.85em">
+                      {{ run.start_time }}
+                    </span>
+                  </td>
+                  <td>
+                    <a href="{% url 'component-detail' run.agent_identifier %}">
+                      {{ run.agent_name }}
+                    </a>
+                  </td>
+                  <td>
+                    <a href="{% url 'component-detail' run.identifier %}">
+                      {{ run.identifier | truncatechars:7 }}
+                    </a>
+                  </td>
+                  <td>
+                    <a href="{% url 'component-detail' run.identifier %}">
+                      {{ run.run_name | truncatechars:40 }}
+                    </a>
+                  </td>
+                  <td>
+                    {{ run.mean_reward | floatformat:"g" }}
+                  </td>
+                  <td>
+                    {{ run.training_episode_count | floatformat:"g" }}
+                  </td>
+                  <td>
+                    {{ run.training_step_count | floatformat:"g" }}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% endfor %}
     {% else %}
       <p>No Environments are available.</p>
     {% endif %}
   </div>
+
 {% endblock content %}

--- a/web/leaderboard/views.py
+++ b/web/leaderboard/views.py
@@ -8,15 +8,13 @@ from registry.models import Component
 
 
 def index(request):
-    # run_obj_by_id, env_obj_by_id, _, terminals, _, _ = Run.agent_run_dags()
-    run_obj_by_id = {}
-    env_obj_by_id = {}
-    terminals = {}
+    agent_run_dags = Component.agent_run_dags()
+    run_obj_by_id, env_obj_by_id, _, terminals, _, _ = agent_run_dags
     env_dict = defaultdict(list)
     for env_id, run_list in terminals.items():
         runs = sorted(
             run_list,
-            key=(lambda i: run_obj_by_id[i].data["metrics"]["mean_reward"]),
+            key=lambda i: run_obj_by_id[i].mean_reward,
             reverse=True,
         )
         env_obj = env_obj_by_id[env_id]

--- a/web/registry/models.py
+++ b/web/registry/models.py
@@ -70,7 +70,7 @@ class Component(TimeStampedModel):
     def start_time(self):
         start_time_ms = int(self.body["info"]["start_time"])
         start_time = datetime.datetime.fromtimestamp(start_time_ms / 1000)
-        return start_time.strftime("%m/%d/%y %H:%m")
+        return start_time.strftime("%m/%d/%y %H:%M")
 
     @property
     def environment(self):


### PR DESCRIPTION
Note: based on PR #400 

This ports the leaderboard landing page (i.e. [http://localhost:8000/](http://localhost:8000/)) to the new Component model.  Here's the result after some local testing:

![Screenshot 2022-06-13 at 14-23-10 AgentOS Leaderboard](https://user-images.githubusercontent.com/25208102/173353788-a4789e04-8d18-4447-8070-66330f8da3b0.png)

A demo script:

```bash
# Start the local web server in a separate tab
# Clear the local DB by visiting http://localhost:8000/empty_database in your browser
cd example_agents/sb3_agent
rm -rf mlruns/
agentos run sb3_agent --function-name learn
agentos run sb3_agent --function-name evaluate
USE_LOCAL_SERVER=True agentos publish <agent run ID printed out after previous previous command>
# Now visit http://localhost:8000 and see the result of your run
```

Next on my list is to port:
* The run details page (currently the links just go to the API endpoint) 
* The tests
