### PR TITLE
Port forward run_detail view

### DIFF
--- a/web/leaderboard/templates/leaderboard/index.html
+++ b/web/leaderboard/templates/leaderboard/index.html
@@ -59,12 +59,12 @@ $(document).ready( function () {
                     </a>
                   </td>
                   <td>
-                    <a href="{% url 'component-detail' run.identifier %}">
+                    <a href="{% url 'identifier' run.identifier %}">
                       {{ run.identifier | truncatechars:7 }}
                     </a>
                   </td>
                   <td>
-                    <a href="{% url 'component-detail' run.identifier %}">
+                    <a href="{% url 'identifier' run.identifier %}">
                       {{ run.run_name | truncatechars:40 }}
                     </a>
                   </td>

--- a/web/leaderboard/templates/leaderboard/run_detail.html
+++ b/web/leaderboard/templates/leaderboard/run_detail.html
@@ -79,14 +79,14 @@ $(document).ready( function () {
     <ul>
       <li>
         Agent:
-        <a href="{% url 'component-detail' run.agent.identifier %}">
-          {{ run.agent.identifier|truncatechars:20 }}
+        <a href="{% url 'component-detail' run.agent_identifier %}">
+          {{ run.agent_identifier|truncatechars:20 }}
         </a>
       </li>
       <li>
         Environment:
-        <a href="{% url 'component-detail' run.environment.identifier %}">
-          {{ run.environment.identifier|truncatechars:20 }}
+        <a href="{% url 'component-detail' run.environment_identifier %}">
+          {{ run.environment_identifier|truncatechars:20 }}
         </a>
       </li>
       <li id="run_info_header">
@@ -97,7 +97,7 @@ $(document).ready( function () {
         <button style="font-size:0.65em; font-weight: bold" class="hide" id="run_info_hide">
           hide
         </button>
-        <pre id="run_info_content" style="display:none">{{ run.info|pprint }}</pre>
+        <pre id="run_info_content" style="display:none">{{ run.body.info|pprint }}</pre>
       </li>
       <li id="run_metrics_header">
         Run.metrics
@@ -107,7 +107,7 @@ $(document).ready( function () {
         <button style="font-size:0.65em; font-weight: bold" class="hide" id="run_metrics_hide">
           hide
         </button>
-        <pre id="run_metrics_content" style="display:none">{{ run.data.metrics|pprint }}</pre>
+        <pre id="run_metrics_content" style="display:none">{{ run.body.data.metrics|pprint }}</pre>
       </li>
       <li id="run_tags_header">
         Run.tags
@@ -117,10 +117,10 @@ $(document).ready( function () {
         <button style="font-size:0.65em; font-weight: bold" class="hide" id="run_tags_hide">
           hide
         </button>
-        <pre id="run_tags_content" style="display:none">{{ run.data.tags|pprint }}</pre>
+        <pre id="run_tags_content" style="display:none">{{ run.body.data.tags|pprint }}</pre>
       </li>
       <li>
-        <a href="{% url 'run-detail' run.identifier %}">View run in REST API</a>
+        <a href="{% url 'component-detail' run.identifier %}">View run in REST API</a>
       </li>
     </ul>
   </div>
@@ -149,16 +149,12 @@ $(document).ready( function () {
           </td>
           <td>
             <a href="/run/{{ r.identifier }}">
-              {% for k, v in r.data.tags.items %}
-                {% if k == "mlflow.runName" %}
-                  {{ v|truncatechars:40 }}
-                {% endif %}
-              {% endfor %}
+              {{ run.run_name|truncatechars:40 }}
             </a>
           </td>
-          <td>{{ r.data.metrics.mean_reward|floatformat:"g" }}</td>
-          <td>{{ r.data.metrics.training_episode_count|floatformat:"g" }}</td>
-          <td>{{ r.data.metrics.training_step_count|floatformat:"g" }}</td>
+          <td>{{ r.mean_reward|floatformat:"g" }}</td>
+          <td>{{ r.training_episode_count|floatformat:"g" }}</td>
+          <td>{{ r.training_step_count|floatformat:"g" }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/web/leaderboard/views.py
+++ b/web/leaderboard/views.py
@@ -41,10 +41,8 @@ def run_list(request):
 
 
 def run_detail(request, identifier):
-    # run = Run.objects.get(identifier=identifier)
-    # run_dag = Run.agent_run_dag(identifier, learn_only=True)
-    run = []
-    run_dag = {}
+    run = Component.objects.get(identifier=identifier)
+    run_dag = Component.agent_run_dag(identifier, learn_only=True)
     context = {"run": run, "run_dag": run_dag, "is_debug": settings.DEBUG}
     return render(request, "leaderboard/run_detail.html", context)
 

--- a/web/registry/models.py
+++ b/web/registry/models.py
@@ -165,7 +165,8 @@ class Component(TimeStampedModel):
         res = [run_map[ident]]
         while ident in graph:
             ident = graph[ident]
-            run_type = run_map[ident].data.get("tags", {}).get("run_type", "")
+            tags = run_map[ident].body['data'].get("tags", {})
+            run_type = tags.get('run_type',"")
             if not learn_only or run_type == "learn":
                 res.append(run_map[ident])
         return res

--- a/web/registry/models.py
+++ b/web/registry/models.py
@@ -165,8 +165,8 @@ class Component(TimeStampedModel):
         res = [run_map[ident]]
         while ident in graph:
             ident = graph[ident]
-            tags = run_map[ident].body['data'].get("tags", {})
-            run_type = tags.get('run_type',"")
+            tags = run_map[ident].body["data"].get("tags", {})
+            run_type = tags.get("run_type", "")
             if not learn_only or run_type == "learn":
                 res.append(run_map[ident])
         return res


### PR DESCRIPTION
This PR ports forward the run_detail view to the new models.  To demo, click the run ID here:

![Screenshot 2022-06-14 at 17-44-40 AgentOS Leaderboard](https://user-images.githubusercontent.com/25208102/173620275-34ccf7ee-dda8-4ae1-bf24-d163bb3074b9.png)

And you should be taken to a page like this:

![Screenshot 2022-06-14 at 17-44-57 Run a6174a2cfb1c9392f9edaa45b28a972fc43b066c](https://user-images.githubusercontent.com/25208102/173620340-21a8cb91-3fe3-46c2-9a9c-cb53ac7bc181.png)

Here's the demo script to populate the DB again:

```bash
# Start the local web server in a separate tab
# Clear the local DB by visiting http://localhost:8000/empty_database in your browser
cd example_agents/sb3_agent
rm -rf mlruns/
agentos run sb3_agent --function-name learn
agentos run sb3_agent --function-name evaluate
USE_LOCAL_SERVER=True agentos publish <agent run ID printed out after previous previous command>
# Now visit http://localhost:8000 and see the result of your run
```

Next on my list is to port:
* ~~The run details page (currently the links just go to the API endpoint)~~
* The run overview page (http://localhost:8000/runs)
* The tests
