### PR TITLE
Port runs page to new models

### DIFF
--- a/example_agents/gh_sb3_agent/components.yaml
+++ b/example_agents/gh_sb3_agent/components.yaml
@@ -31,7 +31,7 @@ specs:
                 type: Module
                 repo: spec:aos_github
                 file_path: example_agents/sb3_agent/agent.py
-                version: test_staging
+                version: test_prod
 
     AtariEnv:
         type: Class
@@ -67,4 +67,4 @@ specs:
             type: Module
             repo: spec:aos_github
             file_path: example_agents/sb3_agent/sb3_run.py
-            version: test_staging
+            version: test_prod

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,7 +20,7 @@ TESTING_GITHUB_REPO = "agentos"
 TESTING_GITHUB_REPO_URL = (
     f"https://github.com/{TESTING_GITHUB_ACCOUNT}/{TESTING_GITHUB_REPO}"
 )
-TESTING_BRANCH_NAME = "test_staging"
+TESTING_BRANCH_NAME = "test_prod"
 
 
 def run_test_command(cli_runner, cmd, cli_args=None, cli_kwargs=None):

--- a/web/leaderboard/templates/leaderboard/index.html
+++ b/web/leaderboard/templates/leaderboard/index.html
@@ -59,12 +59,12 @@ $(document).ready( function () {
                     </a>
                   </td>
                   <td>
-                    <a href="{% url 'identifier' run.identifier %}">
+                    <a href="{% url 'run-detail' run.identifier %}">
                       {{ run.identifier | truncatechars:7 }}
                     </a>
                   </td>
                   <td>
-                    <a href="{% url 'identifier' run.identifier %}">
+                    <a href="{% url 'run-detail' run.identifier %}">
                       {{ run.run_name | truncatechars:40 }}
                     </a>
                   </td>

--- a/web/leaderboard/templates/leaderboard/runs.html
+++ b/web/leaderboard/templates/leaderboard/runs.html
@@ -48,39 +48,35 @@
             <td>
               <span class="start_time">{{ run.start_time }}</span>
             </td>
-            <td><a href="run/{{ run.identifier }}">{{ run.identifier|truncatechars:7 }}</a></td>
             <td>
-              <a href="run/{{ run.identifier }}">
-                {% for k, v in run.data.tags.items %}
-                  {% if k == "mlflow.runName" %}
-                    {{ v|truncatechars:40 }}
-                  {% endif %}
-                {% endfor %}
+                <a href="{% url 'run-detail' run.identifier %}">
+                  {{ run.identifier|truncatechars:7 }}
               </a>
             </td>
             <td>
-              <a href="{% url 'component-detail' run.agent.identifier %}">{{ run.agent.name }}</a>
+              <a href="{% url 'run-detail' run.identifier %}">
+                {{ run.run_name|truncatechars:40 }}
+              </a>
             </td>
             <td>
-              <a href="{% url 'component-detail' run.environment.identifier %}">{{ run.environment.name }}</a>
+              <a href="{% url 'component-detail' run.agent_identifier %}">
+                {{ run.agent_name }}
+              </a>
             </td>
-            {% if run.data.metrics %}
-              {%  for metric_name, metric_val in run.data.metrics.items %}
-                {% if metric_name == "mean_reward" %}
-                  <td>{{ metric_val|floatformat:"g" }}</td>
-                {% endif %}
-                {% if metric_name == "training_episode_count" %}
-                  <td>{{ metric_val|floatformat:"g" }}</td>
-                {% endif %}
-                {% if metric_name == "training_step_count" %}
-                  <td>{{ metric_val|floatformat:"g" }}</td>
-                {% endif %}
-              {% endfor %}
-            {% else %}
-              <td></td>
-              <td></td>
-              <td></td>
-            {%  endif %}
+            <td>
+              <a href="{% url 'component-detail' run.environment_identifier %}">
+                {{ run.environment_name }}
+              </a>
+            </td>
+            <td>
+              {{ run.mean_reward|floatformat:"g" }}
+            </td>
+            <td>
+              {{ run.training_episode_count|floatformat:"g" }}
+            </td>
+            <td>
+              {{ run.training_step_count|floatformat:"g" }}
+            </td>
           </tr>
         {%  endfor %}
         </tbody>
@@ -106,21 +102,21 @@
             <td>
               <span class="start_time">{{ run.start_time }}</span>
             </td>
-            <td><a href="{% url 'run-detail' run.identifier %}">{{ run.identifier|truncatechars:7 }}</a></td>
             <td>
               <a href="{% url 'run-detail' run.identifier %}">
-                {% for k, v in run.data.tags.items %}
-                  {% if k == "mlflow.runName" %}
-                    {{ v|truncatechars:40 }}
-                  {% endif %}
-                {% endfor %}
+                {{ run.identifier|truncatechars:7 }}
               </a>
             </td>
-              <td>
-                <a href="{% url 'runcommand-detail' run.run_command.identifier %}">
-                  {{ run.run_command.identifier }}
-                </a>
-              </td>
+            <td>
+              <a href="{% url 'run-detail' run.identifier %}">
+                {{ run.run_name|truncatechars:40 }}
+              </a>
+            </td>
+            <td>
+              <a href="{% url 'component-detail' run.run_command_identifier %}">
+                {{ run.run_command_identifier }}
+              </a>
+            </td>
           </tr>
         {%  endfor %}
         </tbody>

--- a/web/leaderboard/urls.py
+++ b/web/leaderboard/urls.py
@@ -5,6 +5,6 @@ from . import views
 urlpatterns = [
     path("empty_database", views.empty_database, name="empty-database"),
     path("", views.index, name="index"),
-    path("run/<str:identifier>", views.run_detail, name="identifier"),
-    path("runs", views.run_list),
+    path("run/<str:identifier>", views.run_detail, name="run-detail"),
+    path("runs", views.run_list, name="run-list"),
 ]

--- a/web/leaderboard/views.py
+++ b/web/leaderboard/views.py
@@ -24,14 +24,12 @@ def index(request):
 
 
 def run_list(request):
-    # agent_runs = Run.objects.filter(
-    #    data__tags__contains={"pcs.is_agent_run": "True"}
-    # )
-    # component_runs = Run.objects.filter(
-    #    data__tags__contains={"pcs.is_component_run": "True"}
-    # )
-    agent_runs = []
-    component_runs = []
+    agent_runs = Component.objects.filter(
+        body__data__tags__contains={"pcs.is_agent_run": "True"}
+    )
+    component_runs = Component.objects.filter(
+        body__data__tags__contains={"pcs.is_component_run": "True"}
+    )
     context = {
         "agent_runs": agent_runs,
         "component_runs": component_runs,

--- a/web/registry/models.py
+++ b/web/registry/models.py
@@ -51,6 +51,10 @@ class Component(TimeStampedModel):
         return self.body["data"]["tags"]["agent_identifier"]
 
     @property
+    def run_command_identifier(self):
+        return Component.spec_id_to_identifier(self.body["command"])
+
+    @property
     def run_name(self):
         return self.body["data"]["tags"]["mlflow.runName"]
 
@@ -84,6 +88,10 @@ class Component(TimeStampedModel):
     def agent_name(self):
         instance = Component.get_from_spec_id(self.agent.body["instance_of"])
         return instance.body["name"]
+
+    @property
+    def environment_name(self):
+        return self.environment.body["name"]
 
     @staticmethod
     def create_from_request_data(request_data: QueryDict):


### PR DESCRIPTION
This ports the run overview page ([http://localhost:8000/runs](http://localhost:8000/runs)) to the new models.

![Screenshot 2022-06-15 at 13-40-28 Runs](https://user-images.githubusercontent.com/25208102/173819063-b9eecb0c-52a5-4439-a94f-aef1758e675e.png)

Here's the demo script to populate the DB again:

```bash
# Start the local web server in a separate tab
# Clear the local DB by visiting http://localhost:8000/empty_database in your browser
cd example_agents/sb3_agent
rm -rf mlruns/
agentos run sb3_agent --function-name learn
agentos run sb3_agent --function-name evaluate
USE_LOCAL_SERVER=True agentos publish <agent run ID printed out after previous previous command>
# Now visit http://localhost:8000 and see the result of your run
```

Next on my list is to port, next up are the tests:
* ~~The run details page (currently the links just go to the API endpoint)~~
* ~~The run overview page (http://localhost:8000/runs)~~
* The web tests


