### PR TITLE
Silence dulwich spam in github tests

### DIFF
--- a/pcs/git_manager.py
+++ b/pcs/git_manager.py
@@ -235,7 +235,10 @@ class GitManager:
             print(f"GitManager: fetching {default_repo_path}...")
             with porcelain.open_repo_closing(default_repo_path) as repo:
                 try:
-                    porcelain.fetch(repo)
+                    with open(os.devnull, "wb") as devnull:
+                        porcelain.fetch(
+                            repo, outstream=devnull, errstream=devnull
+                        )
                 except urllib3.exceptions.MaxRetryError:
                     error_msg = (
                         "GitManager: couldn't contact GitHub "
@@ -298,9 +301,13 @@ class GitManager:
         if not clone_destination.exists():
             clone_destination.mkdir(parents=True)
             print(f"GitManager: cloning {src} to {str(clone_destination)}")
-            porcelain.clone(
-                source=str(src), target=str(clone_destination), checkout=True
-            )
+            with open(os.devnull, "wb") as devnull:
+                porcelain.clone(
+                    source=str(src),
+                    target=str(clone_destination),
+                    checkout=True,
+                    errstream=devnull,
+                )
             self._write_repo_info(clone_destination)
             if version:
                 self._checkout_version(clone_destination, version)


### PR DESCRIPTION
This PR silences the dulwich spam (e.g. "Counting objects 1/3000") in the github test logs.  We still have a lot of noise, but now it's from PCS/AOS proper and we clean that up as desired.

[Example logs with this change](https://github.com/agentos-project/agentos/runs/6965505960?check_suite_focus=true)