### PR TITLE
Upload artifacts when publishing AgentRuns

### DIFF
--- a/pcs/registry.py
+++ b/pcs/registry.py
@@ -3,9 +3,6 @@ import json
 import logging
 import os
 import pprint
-import shutil
-import tarfile
-import tempfile
 from collections import defaultdict, deque
 from pathlib import Path, PurePath
 from typing import (
@@ -672,23 +669,6 @@ class WebRegistry(Registry):
                 raise LookupError(response.text)
             else:
                 return False
-
-    def add_run_artifacts(
-        self, run_id: int, run_artifact_paths: Sequence[str]
-    ) -> Sequence:
-        try:
-            tmp_dir_path = Path(tempfile.mkdtemp())
-            tar_gz_path = tmp_dir_path / f"run_{run_id}_artifacts.tar.gz"
-            with tarfile.open(tar_gz_path, "w:gz") as tar:
-                for artifact_path in run_artifact_paths:
-                    tar.add(artifact_path, arcname=artifact_path.name)
-            files = {"tarball": open(tar_gz_path, "rb")}
-            url = f"{self.root_api_url}/runs/{run_id}/upload_artifact/"
-            response = requests.post(url, files=files)
-            result = json.loads(response.content)
-            return result
-        finally:
-            shutil.rmtree(tmp_dir_path)
 
     def to_dict(self) -> Dict:
         raise Exception("to_dict() is not supported on WebRegistry.")

--- a/web/registry/admin.py
+++ b/web/registry/admin.py
@@ -2,4 +2,13 @@ from django.contrib import admin
 
 from .models import Component
 
-admin.site.register(Component)
+
+class ComponentAdmin(admin.ModelAdmin):
+    list_display = ("identifier", "component_type", "artifact_tarball")
+
+    @admin.display(description="Component Type")
+    def component_type(self, obj):
+        return f"{obj.body.get('type', 'unknown')}"
+
+
+admin.site.register(Component, ComponentAdmin)

--- a/web/registry/models.py
+++ b/web/registry/models.py
@@ -39,6 +39,14 @@ class Component(TimeStampedModel):
 
     objects = ComponentManager()
 
+    def __repr__(self):
+        return (
+            "Component<"
+            f"id:{self.identifier}, "
+            f'type:{self.body.get("type", "unknown")}'
+            ">"
+        )
+
     @property
     def model_input_run_identifier(self):
         input_id = self.body["model_input_run"]

--- a/web/registry/views.py
+++ b/web/registry/views.py
@@ -37,7 +37,7 @@ class ComponentViewSet(viewsets.ModelViewSet):
     @transaction.atomic
     def upload_artifact(self, request: Request, pk=None) -> Response:
         component = self.get_object()
-        file_name = "component{component.identifier}_artifacts.tar.gz"
+        file_name = f"component_{component.identifier}_artifacts.tar.gz"
         component.artifact_tarball.save(file_name, request.data["tarball"])
         component.save()
         return Response(ComponentSerializer(component).data)


### PR DESCRIPTION
This PR gets artifact upload working again.  

I think this is the shortest path to getting us back to sharing models; this is basically just porting forward the upload system to the new spec revamp.  

Longer term, we should think more about artifacts being explicitly represented in the DAG (maybe something like a file-in and file-out component?) rather than doing this via a "side-channel" as we do here.

Demo:

```bash
# run the web server in another tab; clear the DB
cd example_agents/sb3_agent
rm -rf mlruns/
agentos run sb3_agent --function-name learn
agentos run sb3_agent --function-name evaluate
USE_LOCAL_SERVER=True agentos publish <id of agent run printed after previous command>
```

If you follow the demo, all the AgentRuns should have tarballs associated with them that contain the model that was trained/evaluated.  For example:

![Screenshot 2022-07-08 at 16-28-16 Select component to change Django site admin](https://user-images.githubusercontent.com/25208102/178025362-9a0b6180-c88f-4dd3-91d1-d1301d7d0593.png)



