### PR TITLE
Demo of versioned dependency install

### DIFF
--- a/documentation/demos/dependency_inference/demo.py
+++ b/documentation/demos/dependency_inference/demo.py
@@ -1,0 +1,25 @@
+import infer  # noqa: F401 isort: skip
+import arrow  # ==1.1.1
+import numpy  # ==1.22.4
+import regex
+
+# NB - latest version of numpy is 1.23.2
+print(
+    f"Numpy version is {numpy.__version__} "
+    '(should be "1.22.4", NOT latest version "1.23.2")'
+)
+assert numpy.__version__ == "1.22.4"
+
+# NB - latest version of arrow is 1.2.2
+print(
+    f"Arrow version is {arrow.__version__} "
+    '(should be "1.1.1", NOT latest version "1.2.2")'
+)
+assert arrow.__version__ == "1.1.1"
+
+# NB - latest version of regex is 2.5.119
+print(
+    f"Regex version is {regex.__version__} "
+    '(should be latest version "2.5.119")'
+)
+assert regex.__version__ == "2.5.119"

--- a/documentation/demos/dependency_inference/infer.py
+++ b/documentation/demos/dependency_inference/infer.py
@@ -1,0 +1,149 @@
+import builtins
+import inspect
+import subprocess
+import sys
+import tokenize
+from pathlib import Path
+
+
+# Let's find the file importing us
+# https://docs.python.org/3/library/inspect.html#the-interpreter-stack
+def get_importing_file():
+    IGNORED_FILES = [
+        "<frozen importlib._bootstrap_external>",
+        "<frozen importlib._bootstrap>",
+    ]
+    curr_frame = inspect.currentframe()
+    try:
+        outer = inspect.getouterframes(curr_frame)
+        for frame in outer:
+            if frame.filename == __file__:
+                continue
+            # consider using code_context here?
+            if frame.filename not in IGNORED_FILES:
+                break
+        else:
+            raise Exception("No import site found")
+        target_file = Path(frame.filename)
+    finally:
+        del frame
+    return target_file
+
+
+# Return a map from {lineno -> comment} for all import statements found
+def get_comment_map(target_file):
+    comment_map = {}
+    with open(target_file, "rb") as fin:
+        in_import = False
+        for token in tokenize.tokenize(fin.readline):
+            if token.type == tokenize.NAME and token.string == "import":
+                in_import = True
+                continue
+            if token.type == tokenize.NEWLINE:
+                in_import = False
+            if token.type == tokenize.COMMENT and in_import:
+                comment_map[token.start[0]] = token.string.strip("#").strip()
+    return comment_map
+
+
+importing_file = get_importing_file()
+comment_map = get_comment_map(importing_file)
+
+print(f"Infer library imported by: {importing_file}")
+print(f"Infer library found the following comments: {comment_map}")
+
+original_import = builtins.__import__
+
+activate_test_meta = False
+comment_version_modifier = ""
+
+
+def new_import(name, globals=None, locals=None, fromlist=(), level=0):
+    global activate_test_meta
+    global comment_version_modifier
+    curr_frame = inspect.currentframe()
+    outer = inspect.getframeinfo(curr_frame.f_back)
+    if outer.filename == str(importing_file):
+        print(f"Infer library detected an import={name}")
+        activate_test_meta = True
+        if outer.lineno in comment_map:
+            comment_version_modifier = comment_map[outer.lineno]
+        else:
+            comment_version_modifier = ""
+        module = original_import(
+            name,
+            globals=globals,
+            locals=locals,
+            fromlist=fromlist,
+            level=level,
+        )
+        activate_test_meta = False
+    else:
+        module = original_import(
+            name,
+            globals=globals,
+            locals=locals,
+            fromlist=fromlist,
+            level=level,
+        )
+    return module
+
+
+builtins.__import__ = new_import
+
+
+# Based on
+# https://realpython.com/python-import/#example-automatically-install-from-pypi
+class TestMeta:
+    @classmethod
+    def find_spec(cls, name, path, target=None):
+        global activate_test_meta
+        global comment_version_modifier
+        if not activate_test_meta:
+            return
+        # print(f"TestMeta: name={name}, path={path}, target={target}:")
+        module_found = False
+        for meta in sys.meta_path:
+            if meta is cls:
+                continue
+            module_spec = meta.find_spec(name, path, target)
+            # print(f"\t META_SEARCH {meta} -> {module_spec}")
+            if module_spec is not None:
+                module_found = True
+        if not module_found:
+            cmd = [
+                str(sys.executable),
+                "-m",
+                "pip",
+                "install",
+                f"{name}{comment_version_modifier}",
+            ]
+            try:
+                subprocess.run(cmd, check=True)
+            except subprocess.CalledProcessError:
+                return None
+        activate_test_meta = False
+
+
+sys.meta_path.insert(0, TestMeta)
+
+# TODO:
+#   * If installed version is as requested, and reinstall if not
+#   * Rewrite file with version annotations
+#   * Cleanup
+#   * Summarize findings and intermediate PR
+#   * Multi-file systems
+
+# Thoughts: some imports the user cares about, internal package imports they
+# probably don't.  Can we distinguish between packages users care about and
+# those that they don't?  Do we have to if we only install if package is
+# missing (seems like numpy internally uses ModuleNotFound)
+
+
+# //NEXT :  PIPFINDER gets the comment map and the metafinder will try to
+# install //specified versions (probably use frame inspection to figure out
+# lineno)
+
+# //the trick will be to distinguish imports the user cares about (i.e. in
+# their //packages) vs imports the user doesn't care about (imports internal to
+# numpy)


### PR DESCRIPTION
Draft PR to show a little demo I've put together per our "rapid prototype" discussion on discord (in case you have a few minutes during baby care).

The demo file contains imports as follows:

```python3
import infer
import arrow  # ==1.1.1
import numpy  # ==1.22.4
import regex
```

If you run `demo.py` on a clean environment, the import of the `infer` package will automatically install the specified versions of `arrow` and `numpy` (note these are **not** the default latest versions) and the latest version of regex.

Here's an example running through the demo script:

```bash
cd documentation/demos/dependency_inference/
virtualenv -p /usr/bin/python3.9 demo_env
source demo_env/bin/activate
python demo.py
```

Some things I've been thinking about as I've been playing with this:
* I have a hypothesis that users care more about some imports than others.  I think they care about imports in the files they've written and less so about internal imports (e.g. when `numpy/__init__.py` initializes and imports all its internal packages).  Right now this demo uses (fragile) heuristics to determine whether or not the import is important.  For unimportant imports (i.e. `numpy` internal imports) we turn off the import intercept machinery.
* In fact, it appears `numpy` uses `ModuleNotFoundErrors` to handle some optional internal extensions.  This presents a problem for a naive "install every not-found package automatically" strategy.
* Next steps I want to work on (all have a fairly clear path, I think):
    * If the wrong version of a requirement is installed, uninstall and then reinstall
    * Rewrite a file with version annotation comments (e.g. pin unversioned imports after it is run)  
    * Expand this to multi-file demos (e.g. `demo.py` imports other user-written code)

